### PR TITLE
feat: normalize supplier pricing by base unit

### DIFF
--- a/lib/pricing/normalize.test.ts
+++ b/lib/pricing/normalize.test.ts
@@ -1,0 +1,62 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  computePrecioUnitarioBase,
+  formatPrecioUnitario,
+  getUnidadBase,
+  isUnidadSoportada,
+  toUnidadBase,
+} from "./normalize";
+
+test("detecta unidad base correcta", () => {
+  assert.strictEqual(getUnidadBase("kg"), "kg");
+  assert.strictEqual(getUnidadBase("g"), "kg");
+  assert.strictEqual(getUnidadBase("ML"), "l");
+  assert.strictEqual(getUnidadBase("docena"), "unidad");
+  assert.strictEqual(getUnidadBase("otra"), null);
+});
+
+test("convierte cantidades a unidad base", () => {
+  assert.ok(Math.abs((toUnidadBase(1_000, "g") ?? 0) - 1) < 1e-9);
+  assert.ok(Math.abs((toUnidadBase(500, "g") ?? 0) - 0.5) < 1e-9);
+  assert.ok(Math.abs((toUnidadBase(250_000, "mg") ?? 0) - 0.25) < 1e-9);
+  assert.ok(Math.abs((toUnidadBase(1_500, "ml") ?? 0) - 1.5) < 1e-9);
+  assert.strictEqual(toUnidadBase(2, "docena"), 24);
+  assert.strictEqual(toUnidadBase(-1, "kg"), null);
+  assert.strictEqual(toUnidadBase(1, "desconocida"), null);
+});
+
+test("calcula precio unitario base", () => {
+  const harina = computePrecioUnitarioBase(20000, 5, "kg");
+  assert.ok(Math.abs((harina.value ?? 0) - 4000) < 1e-6);
+  assert.strictEqual(harina.unidadBase, "kg");
+
+  const semolaGrande = computePrecioUnitarioBase(34000, 10, "kg");
+  assert.ok(Math.abs((semolaGrande.value ?? 0) - 3400) < 1e-6);
+
+  const gramos = computePrecioUnitarioBase(1200, 500, "g");
+  assert.ok(Math.abs((gramos.value ?? 0) - 2400) < 1e-6);
+
+  const docena = computePrecioUnitarioBase(8000, 1, "docena");
+  assert.ok(Math.abs((docena.value ?? 0) - 8000 / 12) < 1e-6);
+  assert.strictEqual(docena.unidadBase, "unidad");
+});
+
+test("maneja datos inválidos", () => {
+  assert.strictEqual(computePrecioUnitarioBase(0, 1, "kg").value, null);
+  assert.strictEqual(computePrecioUnitarioBase(100, 0, "kg").value, null);
+  assert.strictEqual(computePrecioUnitarioBase(100, 1, "desconocida").value, null);
+});
+
+test("formatea precio unitario", () => {
+  const formatted = formatPrecioUnitario(1234.56, "kg", "ARS");
+  assert.ok(formatted.includes("kg"));
+  assert.ok(formatted.includes("$"));
+});
+
+test("detecta unidades soportadas", () => {
+  assert.strictEqual(isUnidadSoportada("kg"), true);
+  assert.strictEqual(isUnidadSoportada("docena"), true);
+  assert.strictEqual(isUnidadSoportada("unknown"), false);
+});

--- a/lib/pricing/normalize.ts
+++ b/lib/pricing/normalize.ts
@@ -1,0 +1,87 @@
+export type BaseUnidad = "kg" | "l" | "unidad";
+
+type ConversionEntry = {
+  base: BaseUnidad;
+  convert: (cantidad: number) => number;
+};
+
+const UNIT_CONVERSIONS: Record<string, ConversionEntry> = {
+  mg: { base: "kg", convert: (cantidad) => cantidad / 1_000_000 },
+  g: { base: "kg", convert: (cantidad) => cantidad / 1_000 },
+  gr: { base: "kg", convert: (cantidad) => cantidad / 1_000 },
+  kilogramo: { base: "kg", convert: (cantidad) => cantidad },
+  kilogramos: { base: "kg", convert: (cantidad) => cantidad },
+  kg: { base: "kg", convert: (cantidad) => cantidad },
+  ml: { base: "l", convert: (cantidad) => cantidad / 1_000 },
+  litro: { base: "l", convert: (cantidad) => cantidad },
+  litros: { base: "l", convert: (cantidad) => cantidad },
+  l: { base: "l", convert: (cantidad) => cantidad },
+  unidad: { base: "unidad", convert: (cantidad) => cantidad },
+  unidades: { base: "unidad", convert: (cantidad) => cantidad },
+  docena: { base: "unidad", convert: (cantidad) => cantidad * 12 },
+  docenas: { base: "unidad", convert: (cantidad) => cantidad * 12 },
+};
+
+function normalizeUnitKey(unidadMedida: string | null | undefined) {
+  return unidadMedida?.trim().toLowerCase() ?? "";
+}
+
+export function getUnidadBase(unidadMedida: string | null | undefined): BaseUnidad | null {
+  const key = normalizeUnitKey(unidadMedida);
+  if (!key) return null;
+  return UNIT_CONVERSIONS[key]?.base ?? null;
+}
+
+export function toUnidadBase(
+  cantidad: number,
+  unidadMedida: string | null | undefined
+): number | null {
+  if (!Number.isFinite(cantidad) || cantidad <= 0) {
+    return null;
+  }
+  const key = normalizeUnitKey(unidadMedida);
+  const entry = UNIT_CONVERSIONS[key];
+  if (!entry) return null;
+  return entry.convert(cantidad);
+}
+
+export function computePrecioUnitarioBase(
+  price: number,
+  quantityNeto: number,
+  unidadMedida: string | null | undefined
+): { value: number | null; unidadBase: BaseUnidad | null } {
+  const unidadBase = getUnidadBase(unidadMedida);
+  if (!Number.isFinite(price) || price <= 0) {
+    return { value: null, unidadBase };
+  }
+  const cantidadBase = toUnidadBase(quantityNeto, unidadMedida);
+  if (!Number.isFinite(cantidadBase) || cantidadBase === null || cantidadBase <= 0) {
+    return { value: null, unidadBase };
+  }
+  const value = price / cantidadBase;
+  if (!Number.isFinite(value) || value <= 0) {
+    return { value: null, unidadBase };
+  }
+  return { value, unidadBase };
+}
+
+export function formatPrecioUnitario(
+  value: number,
+  unidadBase: BaseUnidad,
+  currency = "ARS"
+): string {
+  const formatter = new Intl.NumberFormat("es-AR", {
+    style: "currency",
+    currency: currency?.toUpperCase?.() || "ARS",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  return `${formatter.format(value)} / ${unidadBase}`;
+}
+
+export function isUnidadSoportada(unidadMedida: string | null | undefined): boolean {
+  const key = normalizeUnitKey(unidadMedida);
+  return Boolean(key && UNIT_CONVERSIONS[key]);
+}
+
+export const SUPPORTED_UNITS = Object.freeze(Object.keys(UNIT_CONVERSIONS));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "npx tsc --noEmit false --outDir .tmp-tests lib/pricing/normalize.ts lib/pricing/normalize.test.ts && node --test .tmp-tests/normalize.test.js && rm -rf .tmp-tests"
   },
   "dependencies": {
     "@radix-ui/react-select": "^2.2.5",

--- a/types/ingredient-supplier-price.ts
+++ b/types/ingredient-supplier-price.ts
@@ -9,7 +9,10 @@ export type IngredientSupplierPrice = {
   unitPrice: number;
   currency: string;
   unit: string;
+  quantityNeto?: number | null;
   minOrderQty: number;
   validFrom: string;
   categoria_ingrediente: Category ;
+  precioUnitarioBase?: number | null;
+  unidadBase?: "kg" | "l" | "unidad" | null;
 };

--- a/types/ingredient.ts
+++ b/types/ingredient.ts
@@ -7,6 +7,7 @@ export type IngredientType = {
   ingredienteName: string;
   Stock: number;
   unidadMedida: string;
+  quantityNeto?: number | null;
   precio: number;
   stockUpdatedAt?: string | null;
   categoria_ingrediente: Category


### PR DESCRIPTION
## Summary
- add shared pricing normalization utilities and unit conversion tests
- enrich Strapi mappers, stores, and UI with normalized unit pricing metadata
- surface normalized price badges/ordering plus quantity validation in admin flows

## Testing
- npm test
- npm run lint *(fails: legacy lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a737427c8321983b0c294cb5b443