### PR TITLE
Fix supplier price validation and normalize base price fallback

### DIFF
--- a/app/api/admin/suppliers/strapi-helpers.ts
+++ b/app/api/admin/suppliers/strapi-helpers.ts
@@ -319,9 +319,12 @@ function mapPriceInternal(
   const fallbackUnit = ingrediente?.unidadMedida?.trim?.() ?? "";
   const resolvedUnit = trimmedUnit || fallbackUnit;
 
+  const ingredientQuantity = toNumberOrNull(ingrediente?.quantityNeto);
+  const quantityForNormalization = quantityNeto !== null ? quantityNeto : ingredientQuantity;
+
   const { value: precioUnitarioBase, unidadBase } =
-    quantityNeto !== null && resolvedUnit
-      ? computePrecioUnitarioBase(unitPrice, quantityNeto, resolvedUnit)
+    quantityForNormalization !== null && resolvedUnit
+      ? computePrecioUnitarioBase(unitPrice, quantityForNormalization, resolvedUnit)
       : { value: null, unidadBase: getUnidadBase(resolvedUnit) };
 
   const base: IngredientSupplierPrice = {

--- a/components/sections/admin/suppliers/AddSupplierPriceModal.tsx
+++ b/components/sections/admin/suppliers/AddSupplierPriceModal.tsx
@@ -185,9 +185,13 @@ export function AddSupplierPriceModal({
     const rawQuantityInput = form.quantityNeto.trim();
     const hasQuantityInput = rawQuantityInput !== "";
     const normalizedQuantityString = hasQuantityInput ? rawQuantityInput.replace(/,/g, ".") : "";
-    const parsedQuantity = hasQuantityInput ? Number(normalizedQuantityString) : null;
+    let parsedQuantity: number | null = null;
+    if (hasQuantityInput) {
+      const parsedValue = Number(normalizedQuantityString);
+      parsedQuantity = Number.isFinite(parsedValue) ? parsedValue : null;
+    }
 
-    if (hasQuantityInput && (!Number.isFinite(parsedQuantity) || parsedQuantity <= 0)) {
+    if (hasQuantityInput && (parsedQuantity === null || parsedQuantity <= 0)) {
       setQuantityError("Indicá una cantidad neta mayor a 0");
       return;
     }
@@ -227,7 +231,7 @@ export function AddSupplierPriceModal({
         unitPrice: Number(form.unitPrice),
         currency: normalizeCurrency(form.currency),
         unit: normalizedUnitInput,
-        quantityNeto: parsedQuantity ?? undefined,
+        quantityNeto: hasQuantityInput ? parsedQuantity ?? undefined : undefined,
         minOrderQty: minOrderQtyValue,
         validFrom: form.validFrom ? new Date(form.validFrom).toISOString() : null,
         ingrediente: selectedIngredient


### PR DESCRIPTION
## Summary
- ensure supplier price quantity parsing rejects invalid values without tripping strict null checks
- include quantity presence when building the DTO so empty inputs are omitted cleanly
- compute normalized unit pricing using either the price quantity or the ingredient fallback to keep per-kilo pricing available

## Testing
- `npm run lint` *(fails: pre-existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b146f348832187ccbea8da5fd829