### PR TITLE
Replace ingredient min order field with net quantity

### DIFF
--- a/app/api/admin/ingredients/[id]/route.ts
+++ b/app/api/admin/ingredients/[id]/route.ts
@@ -13,11 +13,17 @@ export async function PUT(
     console.log("📥 PUT recibido body:", body);
     console.log("🆔 Params (documentId):", id);
 
+    const quantityNetoValue =
+      typeof body.quantityNeto === "number" && Number.isFinite(body.quantityNeto)
+        ? body.quantityNeto
+        : null;
+
     const data = {
       ingredienteName: body.ingredienteName,
       Stock: body.Stock,
       unidadMedida: body.unidadMedida,
       precio: body.precio,
+      quantityNeto: quantityNetoValue,
     };
 
     const res = await fetch(`${backend}/api/ingredientes/${id}`, {

--- a/app/api/admin/ingredients/route.ts
+++ b/app/api/admin/ingredients/route.ts
@@ -198,10 +198,16 @@ export async function POST(req: NextRequest) {
 
     const unidadMedidaValue = normalizeString(body.unidadMedida);
 
+    const quantityNetoValue =
+      typeof body.quantityNeto === "number" && Number.isFinite(body.quantityNeto)
+        ? body.quantityNeto
+        : null;
+
     const ingredientData = {
       ingredienteName: body.ingredienteName,
       Stock: body.Stock,
       unidadMedida: unidadMedidaValue,
+      quantityNeto: quantityNetoValue,
       categoria_ingrediente: buildSingleRelation(body.categoria_ingrediente),
       supplier: buildSingleRelation(body.supplier),
       precio: body.precio,

--- a/components/sections/admin/ingredientes/IngredientForm.tsx
+++ b/components/sections/admin/ingredientes/IngredientForm.tsx
@@ -104,13 +104,20 @@ export default function IngredientForm({ form, setForm, onSave }: Props) {
         </select>
       </div>
       <div className="space-y-1">
-        <label className="text-sm font-semibold text-[#5A3E1B]">Cantidad mínima de pedido</label>
+        <label className="text-sm font-semibold text-[#5A3E1B]">Cantidad neta (kilos, planchas, etc.)</label>
         <input
           type="number"
-          placeholder="Cantidad mínima"
-          value={form.minOrderQty}
-          onChange={e => setForm({ ...form, minOrderQty: Number(e.target.value) })}
+          placeholder="Cantidad neta"
+          value={form.quantityNeto ?? ''}
+          onChange={e =>
+            setForm({
+              ...form,
+              quantityNeto: e.target.value === '' ? null : Number(e.target.value),
+            })
+          }
           className="border p-2 rounded w-full"
+          min={0}
+          step="any"
         />
       </div>
       <div className="space-y-1">

--- a/components/sections/admin/ingredientes/hooks/useIngredientesAdmin.ts
+++ b/components/sections/admin/ingredientes/hooks/useIngredientesAdmin.ts
@@ -27,7 +27,7 @@ export function useIngredientesAdmin() {
     unidadMedida: 'kg',
     precio: 0,
     categoria_ingrediente: undefined,
-    minOrderQty: 0,
+    quantityNeto: null,
     validFrom: new Date().toISOString(),
     supplier: undefined,
   });
@@ -51,7 +51,7 @@ export function useIngredientesAdmin() {
         documentId: isNew ? generateSlug(form.ingredienteName) : form.documentId,
         stockUpdatedAt: new Date().toISOString(),
         categoria_ingrediente: form.categoria_ingrediente,
-        minOrderQty: form.minOrderQty,
+        quantityNeto: form.quantityNeto,
         validFrom: form.validFrom,
         supplier: form.supplier,
       };
@@ -104,7 +104,7 @@ export function useIngredientesAdmin() {
       precio: i.precio,
       documentId: i.documentId,
       categoria_ingrediente: i.categoria_ingrediente,
-      minOrderQty: i.minOrderQty,
+      quantityNeto: i.quantityNeto,
       validFrom: i.validFrom,
       supplier: i.supplier,
     });
@@ -118,7 +118,7 @@ export function useIngredientesAdmin() {
     unidadMedida: 'kg',
     precio: 0,
     categoria_ingrediente: undefined,
-    minOrderQty: 0,
+    quantityNeto: null,
     validFrom: new Date().toISOString(),
     supplier: undefined,
     });


### PR DESCRIPTION
## Summary
- replace the ingredient admin form's minimum order input with a net quantity field that accepts kilos, planchas or similar units
- persist the new quantity information when creating or updating ingredients via the admin API helpers
- update the admin ingredient hook defaults and payloads to work with the new quantity data

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b37c45a08321923bd0a4e7059eef