### PR TITLE
Add production ingredient name support in admin

### DIFF
--- a/app/api/admin/ingredients/[id]/route.ts
+++ b/app/api/admin/ingredients/[id]/route.ts
@@ -20,6 +20,7 @@ export async function PUT(
 
     const data = {
       ingredienteName: body.ingredienteName,
+      ingredienteNameProducion: body.ingredienteNameProducion,
       Stock: body.Stock,
       unidadMedida: body.unidadMedida,
       precio: body.precio,

--- a/app/api/admin/ingredients/route.ts
+++ b/app/api/admin/ingredients/route.ts
@@ -205,6 +205,7 @@ export async function POST(req: NextRequest) {
 
     const ingredientData = {
       ingredienteName: body.ingredienteName,
+      ingredienteNameProducion: body.ingredienteNameProducion,
       Stock: body.Stock,
       unidadMedida: unidadMedidaValue,
       quantityNeto: quantityNetoValue,

--- a/app/api/admin/suppliers/strapi-helpers.ts
+++ b/app/api/admin/suppliers/strapi-helpers.ts
@@ -196,6 +196,11 @@ export function mapIngredientFromStrapi(entry: unknown): IngredientType | null {
     ? attributes.name
     : "";
 
+  const ingredienteNameProducion =
+    typeof attributes.ingredienteNameProducion === "string"
+      ? attributes.ingredienteNameProducion
+      : null;
+
   const unidadMedida = typeof attributes.unidadMedida === "string"
     ? attributes.unidadMedida
     : typeof attributes.unit === "string"
@@ -218,6 +223,7 @@ export function mapIngredientFromStrapi(entry: unknown): IngredientType | null {
     id,
     documentId,
     ingredienteName,
+    ingredienteNameProducion,
     Stock: normalizeNumber(attributes.Stock),
     unidadMedida,
     quantityNeto,

--- a/components/sections/admin/ingredientes/IngredientForm.tsx
+++ b/components/sections/admin/ingredientes/IngredientForm.tsx
@@ -30,6 +30,16 @@ export default function IngredientForm({ form, setForm, onSave }: Props) {
         />
       </div>
       <div className="space-y-1">
+        <label className="text-sm font-semibold text-[#5A3E1B]">Nombre para producción</label>
+        <input
+          type="text"
+          placeholder="Detalles para producción"
+          value={form.ingredienteNameProducion || ''}
+          onChange={e => setForm({ ...form, ingredienteNameProducion: e.target.value })}
+          className="border p-2 rounded w-full"
+        />
+      </div>
+      <div className="space-y-1">
         <label className="text-sm font-semibold text-[#5A3E1B]">Stock</label>
         <input
           type="number"

--- a/components/sections/admin/ingredientes/IngredientTable.tsx
+++ b/components/sections/admin/ingredientes/IngredientTable.tsx
@@ -55,7 +55,14 @@ export default function IngredientTable({ ingredientes, onEdit, onDelete, orderB
             <tr key={i.id} className="border-b last:border-none hover:bg-[#FFF8EC] transition">
               <td className="p-3 capitalize font-medium flex items-center gap-2">
               {i.Stock <= 5 && <AlertTriangle className="h-4 w-4 text-red-600" />}
-                {i.ingredienteName}
+                <div className="flex flex-col">
+                  <span>{i.ingredienteName}</span>
+                  {i.ingredienteNameProducion && (
+                    <span className="text-xs font-normal text-[#7a5b3a]">
+                      {i.ingredienteNameProducion}
+                    </span>
+                  )}
+                </div>
               </td>
               <td className="p-3">{i.Stock}</td>
               <td className="p-3 text-xs font-medium bg-[#f2e8da] text-[#5A3E1B] px-2 py-1 rounded-md inline-block">

--- a/components/sections/admin/ingredientes/hooks/useIngredientesAdmin.ts
+++ b/components/sections/admin/ingredientes/hooks/useIngredientesAdmin.ts
@@ -23,6 +23,7 @@ export function useIngredientesAdmin() {
   const [showForm, setShowForm] = useState(false);
   const [form, setForm] = useState<Partial<IngredientType>>({
     ingredienteName: '',
+    ingredienteNameProducion: '',
     Stock: 0,
     unidadMedida: 'kg',
     precio: 0,
@@ -45,6 +46,7 @@ export function useIngredientesAdmin() {
 
       const payload = {
         ingredienteName: form.ingredienteName,
+        ingredienteNameProducion: form.ingredienteNameProducion,
         Stock: form.Stock,
         unidadMedida: form.unidadMedida,
         precio: form.precio,
@@ -99,6 +101,7 @@ export function useIngredientesAdmin() {
     setForm({
       id: i.id,
       ingredienteName: i.ingredienteName,
+      ingredienteNameProducion: i.ingredienteNameProducion,
       Stock: i.Stock,
       unidadMedida: i.unidadMedida,
       precio: i.precio,
@@ -113,10 +116,11 @@ export function useIngredientesAdmin() {
 
   const startNew = () => {
     setForm({
-    ingredienteName: '',
-    Stock: 0,
-    unidadMedida: 'kg',
-    precio: 0,
+      ingredienteName: '',
+      ingredienteNameProducion: '',
+      Stock: 0,
+      unidadMedida: 'kg',
+      precio: 0,
     categoria_ingrediente: undefined,
     quantityNeto: null,
     validFrom: new Date().toISOString(),
@@ -128,7 +132,12 @@ export function useIngredientesAdmin() {
   const ingredientes = data?.items || [];
 
   const filteredAndSortedIngredientes = ingredientes
-    .filter(i => i.ingredienteName?.toLowerCase().includes(search.toLowerCase()))
+    .filter(i => {
+      const term = search.toLowerCase();
+      const name = i.ingredienteName?.toLowerCase() ?? '';
+      const productionName = i.ingredienteNameProducion?.toLowerCase() ?? '';
+      return name.includes(term) || productionName.includes(term);
+    })
     .filter(i => (filterUnidad === 'all' ? true : i.unidadMedida === filterUnidad))
     .filter(i =>
       filterCategoria === 'all'

--- a/types/ingredient.ts
+++ b/types/ingredient.ts
@@ -5,6 +5,7 @@ export type IngredientType = {
   id: number;
   documentId: string;
   ingredienteName: string;
+  ingredienteNameProducion?: string | null;
   Stock: number;
   unidadMedida: string;
   quantityNeto?: number | null;


### PR DESCRIPTION
## Summary
- add the new `ingredienteNameProducion` field to ingredient types and Strapi mappers
- expose the production name input when creating or editing ingredients in the admin UI
- include the production name when listing, creating, and updating ingredients via the admin APIs

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cb62d0b083218143c75fb9f28031