### PR TITLE
Fix ingredient metadata display and defaults

### DIFF
--- a/app/api/admin/ingredients/route.ts
+++ b/app/api/admin/ingredients/route.ts
@@ -231,6 +231,9 @@ export async function POST(req: NextRequest) {
       ingrediente: newIngredientId,
       supplier: buildSingleRelation(body.supplier),
       categoria_ingrediente: buildSingleRelation(body.categoria_ingrediente), // This was the missing field
+      validFrom: typeof body.validFrom === "string" && body.validFrom.trim() !== ""
+        ? body.validFrom
+        : new Date().toISOString(),
     };
 
     await createIngredientSupplierPrice(priceData);

--- a/components/sections/admin/ingredientes/IngredientForm.tsx
+++ b/components/sections/admin/ingredientes/IngredientForm.tsx
@@ -17,6 +17,18 @@ export default function IngredientForm({ form, setForm, onSave }: Props) {
   const { data: suppliers, isLoading: isLoadingSuppliers } = useGetSuppliers();
   const { data: categories, isLoading: isLoadingCategories } = useGetIngredientCategories();
   const categoryItems: Category[] = Array.isArray(categories) ? categories : categories?.items ?? [];
+  const todayValue = new Date().toISOString().split('T')[0];
+  const validFromValue = (() => {
+    if (!form.validFrom) return todayValue;
+    const parsed = new Date(form.validFrom);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString().split('T')[0];
+    }
+    if (typeof form.validFrom === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(form.validFrom.trim())) {
+      return form.validFrom.trim();
+    }
+    return todayValue;
+  })();
   return (
     <div className="bg-white p-4 rounded-xl shadow space-y-4 max-w-md">
       <div className="space-y-1">
@@ -134,7 +146,7 @@ export default function IngredientForm({ form, setForm, onSave }: Props) {
         <label className="text-sm font-semibold text-[#5A3E1B]">Válido desde</label>
         <input
           type="date"
-          value={form.validFrom ? new Date(form.validFrom).toISOString().split('T')[0] : ''}
+          value={validFromValue}
           onChange={e => setForm({ ...form, validFrom: e.target.value })}
           className="border p-2 rounded w-full"
         />

--- a/components/sections/admin/ingredientes/IngredientTable.tsx
+++ b/components/sections/admin/ingredientes/IngredientTable.tsx
@@ -16,6 +16,13 @@ export default function IngredientTable({ ingredientes, onEdit, onDelete, orderB
   const [showPrices, setShowPrices] = useState(false);
   const [selectedIngredient, setSelectedIngredient] = useState<IngredientType | null>(null);
 
+  const formatDateTime = (value?: string | null) => {
+    if (!value) return '-';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '-';
+    return date.toLocaleString('es-AR');
+  };
+
   const handleSort = (field: keyof IngredientType) => {
     const newDirection = orderBy.field === field && orderBy.direction === 'asc' ? 'desc' : 'asc';
     setOrderBy({ field, direction: newDirection });
@@ -46,6 +53,9 @@ export default function IngredientTable({ ingredientes, onEdit, onDelete, orderB
             <th className="p-3 text-left cursor-pointer" onClick={() => handleSort('precio')}>
               Precio <ArrowUpDown className="inline h-3 w-3 ml-1" />
             </th>
+            <th className="p-3 text-left">Cantidad neta</th>
+            <th className="p-3 text-left">Proveedor</th>
+            <th className="p-3 text-left">Categoría</th>
             <th className="p-3 text-left">Actualizado</th>
             <th className="p-3 text-center">Acciones</th>
           </tr>
@@ -69,9 +79,10 @@ export default function IngredientTable({ ingredientes, onEdit, onDelete, orderB
                 {i.unidadMedida}
               </td>
               <td className="p-3 font-semibold">${i.precio.toLocaleString('es-AR')}</td>
-              <td className="p-3 text-xs text-gray-500">
-                {i.stockUpdatedAt ? new Date(i.stockUpdatedAt).toLocaleString('es-AR') : '-'}
-              </td>
+              <td className="p-3">{i.quantityNeto != null ? i.quantityNeto.toLocaleString('es-AR') : '-'}</td>
+              <td className="p-3">{i.supplier?.name ?? '-'}</td>
+              <td className="p-3">{i.categoria_ingrediente?.nombre ?? '-'}</td>
+              <td className="p-3 text-xs text-gray-500">{formatDateTime(i.updatedAt ?? i.stockUpdatedAt ?? null)}</td>
               <td className="p-3 text-center flex justify-center gap-3">
                 <button
                   onClick={() => handleOpenPrices(i)}

--- a/components/sections/admin/ingredientes/hooks/useIngredientesAdmin.ts
+++ b/components/sections/admin/ingredientes/hooks/useIngredientesAdmin.ts
@@ -15,6 +15,27 @@ export function useIngredientesAdmin() {
   const [filterCategoria, setFilterCategoria] = useState<number | 'all'>('all');
   const [filterLowStock, setFilterLowStock] = useState(false);
 
+  const todayInputValue = () => new Date().toISOString().split('T')[0];
+  const normalizeDateInput = (value?: string | null) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+      return todayInputValue();
+    }
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString().split('T')[0];
+    }
+    if (/^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+      return value.trim();
+    }
+    return todayInputValue();
+  };
+  const toISOStringOrNull = (value?: string | null) => {
+    if (typeof value !== 'string' || value.trim() === '') return null;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return null;
+    return parsed.toISOString();
+  };
+
   const [orderBy, setOrderBy] = useState({
     field: 'ingredienteName' as keyof IngredientType,
     direction: 'asc' as 'asc' | 'desc',
@@ -29,7 +50,7 @@ export function useIngredientesAdmin() {
     precio: 0,
     categoria_ingrediente: undefined,
     quantityNeto: null,
-    validFrom: new Date().toISOString(),
+    validFrom: todayInputValue(),
     supplier: undefined,
   });
 
@@ -44,6 +65,7 @@ export function useIngredientesAdmin() {
     try {
       const isNew = !form.id;
 
+      const validFromISO = toISOStringOrNull(form.validFrom) ?? new Date().toISOString();
       const payload = {
         ingredienteName: form.ingredienteName,
         ingredienteNameProducion: form.ingredienteNameProducion,
@@ -54,7 +76,7 @@ export function useIngredientesAdmin() {
         stockUpdatedAt: new Date().toISOString(),
         categoria_ingrediente: form.categoria_ingrediente,
         quantityNeto: form.quantityNeto,
-        validFrom: form.validFrom,
+        validFrom: validFromISO,
         supplier: form.supplier,
       };
 
@@ -108,7 +130,7 @@ export function useIngredientesAdmin() {
       documentId: i.documentId,
       categoria_ingrediente: i.categoria_ingrediente,
       quantityNeto: i.quantityNeto,
-      validFrom: i.validFrom,
+      validFrom: normalizeDateInput(i.validFrom),
       supplier: i.supplier,
     });
     setShowForm(true);
@@ -121,10 +143,10 @@ export function useIngredientesAdmin() {
       Stock: 0,
       unidadMedida: 'kg',
       precio: 0,
-    categoria_ingrediente: undefined,
-    quantityNeto: null,
-    validFrom: new Date().toISOString(),
-    supplier: undefined,
+      categoria_ingrediente: undefined,
+      quantityNeto: null,
+      validFrom: todayInputValue(),
+      supplier: undefined,
     });
     setShowForm(true);
   };

--- a/types/ingredient.ts
+++ b/types/ingredient.ts
@@ -11,7 +11,8 @@ export type IngredientType = {
   quantityNeto?: number | null;
   precio: number;
   stockUpdatedAt?: string | null;
-  categoria_ingrediente: Category
+  updatedAt?: string | null;
+  categoria_ingrediente: Category;
   supplier?: SupplierType;
   minOrderQty?: number;
   validFrom?: string;


### PR DESCRIPTION
## Summary
- expose supplier, category, valid-from and update timestamps when mapping ingredients from Strapi
- default the "Válido desde" form field to today and normalize the value before saving
- enrich the admin ingredient table with supplier, category, net quantity and a corrected "Actualizado" column
- persist supplier/category edits and send the valid-from date when creating ingredient prices

## Testing
- npm run lint *(fails: pre-existing lint errors across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cdf295c883218d53ff6dfcc07fc5