### PR TITLE
Add admin ingredient category management page

### DIFF
--- a/app/admin/categoria_ingrediente/page.tsx
+++ b/app/admin/categoria_ingrediente/page.tsx
@@ -1,0 +1,5 @@
+import IngredientCategoriesSection from "@/components/sections/admin/ingredient-categories/IngredientCategoriesSection";
+
+export default function IngredientCategoriesPage() {
+  return <IngredientCategoriesSection />;
+}

--- a/app/api/admin/ingredient-categories/[id]/route.ts
+++ b/app/api/admin/ingredient-categories/[id]/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+import { strapiFetch } from "../../suppliers/strapi-helpers";
+import { isRecord, mapCategoryWithRelations } from "../utils";
+
+function sanitizeUpdatePayload(body: unknown) {
+  if (!isRecord(body)) {
+    throw new Error("Datos inválidos");
+  }
+
+  const nombreValue = body.nombre;
+  const descriptionValue = body.description;
+
+  const nombre = typeof nombreValue === "string" ? nombreValue.trim() : "";
+  if (!nombre) {
+    throw new Error("El nombre es obligatorio");
+  }
+
+  const description =
+    typeof descriptionValue === "string" ? descriptionValue.trim() : undefined;
+
+  const payload: Record<string, unknown> = { nombre };
+  payload.description = description && description.length > 0 ? description : null;
+
+  return payload;
+}
+
+export async function PUT(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+
+  try {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: "Datos inválidos", details: "JSON inválido" },
+        { status: 400 }
+      );
+    }
+
+    let payload: Record<string, unknown>;
+    try {
+      payload = sanitizeUpdatePayload(body);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Datos inválidos";
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+
+    const res = await strapiFetch(`/api/categoria-ingredientes/${id}`, {
+      method: "PUT",
+      body: JSON.stringify({ data: payload }),
+    });
+
+    let json: unknown = null;
+    try {
+      json = await res.json();
+    } catch (error) {
+      console.error("[admin/ingredient-categories][PUT] parse error", error);
+    }
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Error actualizando categoría", details: json },
+        { status: res.status || 500 }
+      );
+    }
+
+    const category = mapCategoryWithRelations(isRecord(json) ? (json as Record<string, unknown>).data : json);
+    if (!category) {
+      return NextResponse.json(
+        { error: "Respuesta inválida del servidor" },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ data: category });
+  } catch (error) {
+    console.error("[admin/ingredient-categories][PUT] unexpected error", error);
+    return NextResponse.json(
+      { error: "Error inesperado", details: String(error instanceof Error ? error.message : error) },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const { id } = await context.params;
+
+  try {
+    const res = await strapiFetch(`/api/categoria-ingredientes/${id}`, {
+      method: "DELETE",
+    });
+
+    if (res.status === 204) {
+      return new Response(null, { status: 204 });
+    }
+
+    let json: unknown = null;
+    try {
+      json = await res.json();
+    } catch (error) {
+      console.error("[admin/ingredient-categories][DELETE] parse error", error);
+    }
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { error: "Error eliminando categoría", details: json },
+        { status: res.status || 500 }
+      );
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[admin/ingredient-categories][DELETE] unexpected error", error);
+    return NextResponse.json(
+      { error: "Error inesperado", details: String(error instanceof Error ? error.message : error) },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/ingredient-categories/utils.ts
+++ b/app/api/admin/ingredient-categories/utils.ts
@@ -1,0 +1,56 @@
+import type { Category } from "@/types/categoria_ingrediente";
+import {
+  mapCategoryFromStrapi,
+  mapIngredientFromStrapi,
+  mapPriceFromStrapi,
+} from "../suppliers/strapi-helpers";
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractRelationArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (isRecord(value) && Array.isArray(value.data)) return value.data;
+  return [];
+}
+
+export function mapCategoryWithRelations(entry: unknown): Category | null {
+  const base = mapCategoryFromStrapi(entry);
+  if (!base) return null;
+
+  const normalized = isRecord(entry) ? (entry as Record<string, unknown>) : null;
+  const attributes: Record<string, unknown> =
+    normalized && isRecord(normalized.attributes)
+      ? (normalized.attributes as Record<string, unknown>)
+      : normalized ?? {};
+
+  const normalizedRecord = normalized as Record<string, unknown> | null;
+
+  const ingredientesSource =
+    attributes["ingredientes"] ?? normalizedRecord?.["ingredientes"];
+  const ingredientesRaw = extractRelationArray(ingredientesSource);
+  const ingredientes = ingredientesRaw
+    .map((item) => mapIngredientFromStrapi(item))
+    .filter(
+      (item): item is NonNullable<ReturnType<typeof mapIngredientFromStrapi>> =>
+        Boolean(item)
+    );
+
+  const pricesSource =
+    attributes["ingredient_supplier_prices"] ??
+    normalizedRecord?.["ingredient_supplier_prices"];
+  const ingredientSupplierPricesRaw = extractRelationArray(pricesSource);
+  const ingredient_supplier_prices = ingredientSupplierPricesRaw
+    .map((item) => mapPriceFromStrapi(item))
+    .filter(
+      (item): item is NonNullable<ReturnType<typeof mapPriceFromStrapi>> =>
+        Boolean(item)
+    );
+
+  return {
+    ...base,
+    ingredientes,
+    ingredient_supplier_prices,
+  };
+}

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Home, ShoppingCart, Package, Users, Utensils, DollarSign, Truck, Wheat  } from 'lucide-react';
+import { Home, ShoppingCart, Package, Users, Utensils, DollarSign, Truck, Wheat, Tags } from 'lucide-react';
 
 export function Sidebar() {
   return (
@@ -20,6 +20,10 @@ export function Sidebar() {
         <Link href="/admin/ingredientes" className="flex items-center space-x-2 text-gray-700 hover:text-gray-900">
           <Wheat size={20} />
           <span>ingredientes</span>
+        </Link>
+        <Link href="/admin/categoria_ingrediente" className="flex items-center space-x-2 text-gray-700 hover:text-gray-900">
+          <Tags size={20} />
+          <span>Categorías</span>
         </Link>
         <Link href="/admin/recetas" className="flex items-center space-x-2 text-gray-700 hover:text-gray-900">
           <Utensils size={20} />

--- a/components/sections/admin/ingredient-categories/IngredientCategoriesSection.tsx
+++ b/components/sections/admin/ingredient-categories/IngredientCategoriesSection.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { Loader2, Plus } from "lucide-react";
+import { IngredientCategoryForm } from "./IngredientCategoryForm";
+import { IngredientCategoryTable } from "./IngredientCategoryTable";
+import { useIngredientCategoriesAdmin } from "./hooks/useIngredientCategoriesAdmin";
+
+export default function IngredientCategoriesSection() {
+  const {
+    categories,
+    total,
+    loading,
+    error,
+    search,
+    setSearch,
+    showForm,
+    startNew,
+    editCategory,
+    deleteCategory,
+    form,
+    setForm,
+    saveCategory,
+    resetForm,
+    saving,
+    deletingId,
+    isEditing,
+  } = useIngredientCategoriesAdmin();
+
+  if (loading && categories.length === 0) {
+    return (
+      <div className="flex w-full justify-center py-10">
+        <Loader2 className="h-6 w-6 animate-spin text-[#8B4513]" />
+      </div>
+    );
+  }
+
+  const headerSubtitle = total === 1 ? "1 categoría" : `${total} categorías`;
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-[#8B4513] font-garamond">
+            Categorías de ingredientes
+          </h1>
+          <p className="text-sm text-gray-600">{headerSubtitle}</p>
+        </div>
+        <button
+          type="button"
+          onClick={startNew}
+          className="inline-flex items-center gap-2 rounded-2xl bg-[#8B4513] px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-[#5A3E1B]"
+        >
+          <Plus className="h-4 w-4" />
+          Nueva categoría
+        </button>
+      </header>
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Buscar por nombre o descripción"
+          className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[#8B4513] focus:outline-none focus:ring-2 focus:ring-[#8B4513]/40 sm:max-w-sm"
+        />
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {showForm && (
+        <div className="space-y-4 rounded-2xl bg-white p-5 shadow">
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-semibold text-[#8B4513]">
+              {isEditing ? "Editar categoría" : "Nueva categoría"}
+            </h2>
+            <button
+              type="button"
+              onClick={resetForm}
+              className="text-sm text-gray-500 transition hover:text-gray-700"
+            >
+              Cancelar
+            </button>
+          </div>
+          <IngredientCategoryForm
+            form={form}
+            setForm={setForm}
+            onSave={saveCategory}
+            onCancel={resetForm}
+            saving={saving}
+            isEditing={isEditing}
+          />
+        </div>
+      )}
+
+      <IngredientCategoryTable
+        categories={categories}
+        onEdit={editCategory}
+        onDelete={deleteCategory}
+        deletingId={deletingId}
+      />
+    </section>
+  );
+}

--- a/components/sections/admin/ingredient-categories/IngredientCategoryForm.tsx
+++ b/components/sections/admin/ingredient-categories/IngredientCategoryForm.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Dispatch, FormEvent, SetStateAction } from "react";
+import { Loader2 } from "lucide-react";
+import type { CategoryFormState } from "./hooks/useIngredientCategoriesAdmin";
+
+interface IngredientCategoryFormProps {
+  form: CategoryFormState;
+  setForm: Dispatch<SetStateAction<CategoryFormState>>;
+  onSave: () => Promise<void> | void;
+  onCancel: () => void;
+  saving: boolean;
+  isEditing: boolean;
+}
+
+export function IngredientCategoryForm({
+  form,
+  setForm,
+  onSave,
+  onCancel,
+  saving,
+  isEditing,
+}: IngredientCategoryFormProps) {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await onSave();
+  };
+
+  return (
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="sm:col-span-1">
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="category-name">
+            Nombre <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="category-name"
+            type="text"
+            value={form.nombre}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, nombre: event.target.value }))
+            }
+            placeholder="Ej. Lácteos"
+            className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[#8B4513] focus:outline-none focus:ring-2 focus:ring-[#8B4513]/40"
+            required
+          />
+        </div>
+        <div className="sm:col-span-1">
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="category-description">
+            Descripción
+          </label>
+          <textarea
+            id="category-description"
+            value={form.description}
+            onChange={(event) =>
+              setForm((prev) => ({ ...prev, description: event.target.value }))
+            }
+            placeholder="Descripción opcional"
+            rows={3}
+            className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[#8B4513] focus:outline-none focus:ring-2 focus:ring-[#8B4513]/40"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="inline-flex items-center justify-center rounded-2xl border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
+          disabled={saving}
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          className="inline-flex items-center justify-center rounded-2xl bg-[#8B4513] px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-[#5A3E1B] disabled:opacity-70"
+          disabled={saving}
+        >
+          {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {isEditing ? "Guardar cambios" : "Crear categoría"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/sections/admin/ingredient-categories/IngredientCategoryTable.tsx
+++ b/components/sections/admin/ingredient-categories/IngredientCategoryTable.tsx
@@ -1,0 +1,124 @@
+import { Pencil, Trash2 } from "lucide-react";
+import type { Category } from "@/types/categoria_ingrediente";
+
+interface IngredientCategoryTableProps {
+  categories: Category[];
+  onEdit: (category: Category) => void;
+  onDelete: (category: Category) => void;
+  deletingId: string | null;
+}
+
+export function IngredientCategoryTable({
+  categories,
+  onEdit,
+  onDelete,
+  deletingId,
+}: IngredientCategoryTableProps) {
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-gray-200 bg-white shadow">
+      <table className="min-w-full text-sm text-gray-800">
+        <thead className="bg-gray-100 text-xs uppercase tracking-wider text-gray-600">
+          <tr>
+            <th scope="col" className="px-5 py-3 text-left font-semibold">
+              Nombre
+            </th>
+            <th scope="col" className="px-5 py-3 text-left font-semibold">
+              Descripción
+            </th>
+            <th scope="col" className="px-5 py-3 text-left font-semibold">
+              Ingredientes asociados
+            </th>
+            <th scope="col" className="px-5 py-3 text-center font-semibold">
+              Acciones
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {categories.length === 0 ? (
+            <tr>
+              <td
+                colSpan={4}
+                className="px-5 py-6 text-center text-sm text-gray-500"
+              >
+                No hay categorías cargadas todavía.
+              </td>
+            </tr>
+          ) : (
+            categories.map((category, index) => {
+              const deleteIdentifier =
+                category.documentId || (category.id ? String(category.id) : null);
+              const rowKey =
+                deleteIdentifier || category.nombre || `categoria-${index}`;
+              const isDeleting =
+                deleteIdentifier != null && deletingId === deleteIdentifier;
+              const canDelete = Boolean(deleteIdentifier);
+              const ingredientCount = category.ingredientes?.length ?? 0;
+
+              return (
+                <tr key={rowKey} className="transition hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-5 py-4 font-medium">
+                    {category.nombre || "Sin nombre"}
+                  </td>
+                  <td className="px-5 py-4 text-gray-600">
+                    {category.description && category.description.trim() !== ""
+                      ? category.description
+                      : "Sin descripción"}
+                  </td>
+                  <td className="px-5 py-4">
+                    <span className="inline-flex items-center rounded-full bg-[#F7EDE2] px-3 py-1 text-xs font-medium text-[#8B4513]">
+                      {ingredientCount} ingrediente{ingredientCount === 1 ? "" : "s"}
+                    </span>
+                  </td>
+                  <td className="px-5 py-4">
+                    <div className="flex items-center justify-center gap-3">
+                      <button
+                        type="button"
+                        onClick={() => onEdit(category)}
+                        className="text-[#8B4513] transition hover:text-[#5A3E1B]"
+                        aria-label="Editar categoría"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onDelete(category)}
+                        className="text-red-500 transition hover:text-red-600"
+                        aria-label="Eliminar categoría"
+                        disabled={!canDelete || isDeleting}
+                      >
+                        {isDeleting ? (
+                          <svg
+                            className="h-4 w-4 animate-spin text-red-500"
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                          >
+                            <circle
+                              className="opacity-25"
+                              cx="12"
+                              cy="12"
+                              r="10"
+                              stroke="currentColor"
+                              strokeWidth="4"
+                            ></circle>
+                            <path
+                              className="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"
+                            ></path>
+                          </svg>
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/sections/admin/ingredient-categories/hooks/useIngredientCategoriesAdmin.ts
+++ b/components/sections/admin/ingredient-categories/hooks/useIngredientCategoriesAdmin.ts
@@ -1,0 +1,214 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import type { Category } from "@/types/categoria_ingrediente";
+import { useGetIngredientCategories } from "@/components/hooks/useGetIngredientCategories";
+
+export type CategoryFormState = {
+  id?: number;
+  documentId?: string;
+  nombre: string;
+  description: string;
+};
+
+const EMPTY_FORM: CategoryFormState = {
+  nombre: "",
+  description: "",
+};
+
+export function useIngredientCategoriesAdmin() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError, error, refetch } = useGetIngredientCategories();
+
+  const [search, setSearch] = useState("");
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState<CategoryFormState>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const categories = useMemo<Category[]>(
+    () => (Array.isArray(data) ? data : []),
+    [data]
+  );
+
+  const normalizedSearch = search.trim().toLowerCase();
+  const filteredCategories = useMemo(() => {
+    if (!normalizedSearch) {
+      return [...categories].sort((a, b) =>
+        (a.nombre ?? "").localeCompare(b.nombre ?? "", "es", { sensitivity: "base" })
+      );
+    }
+
+    return categories
+      .filter((category) => {
+        const name = category.nombre?.toLowerCase?.() ?? "";
+        const description = category.description?.toLowerCase?.() ?? "";
+        return (
+          name.includes(normalizedSearch) ||
+          (description ? description.includes(normalizedSearch) : false)
+        );
+      })
+      .sort((a, b) =>
+        (a.nombre ?? "").localeCompare(b.nombre ?? "", "es", { sensitivity: "base" })
+      );
+  }, [categories, normalizedSearch]);
+
+  const total = categories.length;
+  const errorMessage = isError
+    ? error instanceof Error
+      ? error.message
+      : "No se pudieron cargar las categorías"
+    : null;
+
+  const resetForm = () => {
+    setForm(EMPTY_FORM);
+    setShowForm(false);
+  };
+
+  const startNew = () => {
+    setForm(EMPTY_FORM);
+    setShowForm(true);
+  };
+
+  const editCategory = (category: Category) => {
+    setForm({
+      id: category.id,
+      documentId: category.documentId,
+      nombre: category.nombre ?? "",
+      description: category.description ?? "",
+    });
+    setShowForm(true);
+  };
+
+  const invalidateCategories = async () => {
+    await queryClient.invalidateQueries({ queryKey: ["ingredient-categories"] });
+    await refetch();
+  };
+
+  const saveCategory = async () => {
+    if (!form.nombre.trim()) {
+      toast.error("El nombre es obligatorio");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const isEditing = Boolean(form.documentId || form.id);
+      const identifier = form.documentId || (form.id ? String(form.id) : "");
+      if (isEditing && !identifier) {
+        toast.error("No se pudo identificar la categoría");
+        return;
+      }
+      const url = isEditing
+        ? `/api/admin/ingredient-categories/${identifier}`
+        : "/api/admin/ingredient-categories";
+      const method = isEditing ? "PUT" : "POST";
+
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          nombre: form.nombre,
+          description: form.description,
+        }),
+      });
+
+      if (res.status === 204) {
+        toast.success(isEditing ? "Categoría actualizada" : "Categoría creada");
+        await invalidateCategories();
+        resetForm();
+        return;
+      }
+
+      if (!res.ok) {
+        let errorMessage = isEditing
+          ? "No se pudo actualizar la categoría"
+          : "No se pudo crear la categoría";
+        try {
+          const json = await res.json();
+          if (json?.error) {
+            errorMessage = json.error as string;
+          }
+        } catch (parseError) {
+          console.error("[useIngredientCategoriesAdmin][saveCategory] parse error", parseError);
+        }
+        throw new Error(errorMessage);
+      }
+
+      toast.success(isEditing ? "Categoría actualizada" : "Categoría creada");
+      await invalidateCategories();
+      resetForm();
+    } catch (error) {
+      console.error("[useIngredientCategoriesAdmin] save error", error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Ocurrió un error al guardar la categoría"
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteCategory = async (category: Category) => {
+    const identifier = category.documentId || (category.id ? String(category.id) : "");
+    if (!identifier) {
+      toast.error("No se pudo identificar la categoría");
+      return;
+    }
+
+    setDeletingId(identifier);
+    try {
+      const res = await fetch(`/api/admin/ingredient-categories/${identifier}`, {
+        method: "DELETE",
+      });
+
+      if (res.status !== 204 && !res.ok) {
+        let message = "No se pudo eliminar la categoría";
+        try {
+          const json = await res.json();
+          if (json?.error) {
+            message = json.error as string;
+          }
+        } catch (parseError) {
+          console.error("[useIngredientCategoriesAdmin][deleteCategory] parse error", parseError);
+        }
+        throw new Error(message);
+      }
+
+      toast.success("Categoría eliminada");
+      await invalidateCategories();
+    } catch (error) {
+      console.error("[useIngredientCategoriesAdmin] delete error", error);
+      toast.error(
+        error instanceof Error ? error.message : "Ocurrió un error al eliminar"
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const isEditing = Boolean(form.documentId || form.id);
+
+  return {
+    categories: filteredCategories,
+    total,
+    loading: isLoading,
+    error: errorMessage,
+    search,
+    setSearch,
+    showForm,
+    startNew,
+    editCategory,
+    deleteCategory,
+    form,
+    setForm,
+    saveCategory,
+    resetForm,
+    saving,
+    deletingId,
+    isEditing,
+  };
+}


### PR DESCRIPTION
## Summary
- add an admin route and navigation entry for managing ingredient categories
- implement Strapi-backed CRUD API handlers for ingredient categories
- build UI components and state hook to list, create, edit, and delete categories with validation

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d0d4090c8321a357cc30217708a5