### PR TITLE
Fix ingredient category description payload

### DIFF
--- a/app/api/admin/ingredient-categories/[id]/route.ts
+++ b/app/api/admin/ingredient-categories/[id]/route.ts
@@ -19,7 +19,13 @@ function sanitizeUpdatePayload(body: unknown) {
     typeof descriptionValue === "string" ? descriptionValue.trim() : undefined;
 
   const payload: Record<string, unknown> = { nombre };
-  payload.description = description && description.length > 0 ? description : null;
+  if (description && description.length > 0) {
+    payload.description = description;
+    payload.descripcion = description;
+  } else {
+    payload.description = null;
+    payload.descripcion = null;
+  }
 
   return payload;
 }

--- a/app/api/admin/ingredient-categories/route.ts
+++ b/app/api/admin/ingredient-categories/route.ts
@@ -64,7 +64,13 @@ function sanitizeCategoryPayload(body: unknown) {
     documentId: generateSlug(nombre),
   };
 
-  payload.description = description && description.length > 0 ? description : null;
+  if (description && description.length > 0) {
+    payload.description = description;
+    payload.descripcion = description;
+  } else {
+    payload.description = null;
+    payload.descripcion = null;
+  }
 
   return payload;
 }


### PR DESCRIPTION
## Summary
- ensure ingredient category create/update requests send both description and descripcion fields

## Testing
- `npm run lint` *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d9cbef68832195b5b3929df9aa9a