### PR TITLE
Remove ingredient category description field

### DIFF
--- a/app/api/admin/ingredient-categories/[id]/route.ts
+++ b/app/api/admin/ingredient-categories/[id]/route.ts
@@ -8,26 +8,11 @@ function sanitizeUpdatePayload(body: unknown) {
   }
 
   const nombreValue = body.nombre;
-  const descriptionValue = body.description;
-
   const nombre = typeof nombreValue === "string" ? nombreValue.trim() : "";
   if (!nombre) {
     throw new Error("El nombre es obligatorio");
   }
-
-  const description =
-    typeof descriptionValue === "string" ? descriptionValue.trim() : undefined;
-
-  const payload: Record<string, unknown> = { nombre };
-  if (description && description.length > 0) {
-    payload.description = description;
-    payload.descripcion = description;
-  } else {
-    payload.description = null;
-    payload.descripcion = null;
-  }
-
-  return payload;
+  return { nombre };
 }
 
 export async function PUT(

--- a/app/api/admin/ingredient-categories/route.ts
+++ b/app/api/admin/ingredient-categories/route.ts
@@ -49,28 +49,15 @@ function sanitizeCategoryPayload(body: unknown) {
   }
 
   const nombreValue = body.nombre;
-  const descriptionValue = body.description;
-
   const nombre = typeof nombreValue === "string" ? nombreValue.trim() : "";
   if (!nombre) {
     throw new Error("El nombre es obligatorio");
   }
 
-  const description =
-    typeof descriptionValue === "string" ? descriptionValue.trim() : undefined;
-
   const payload: Record<string, unknown> = {
     nombre,
     documentId: generateSlug(nombre),
   };
-
-  if (description && description.length > 0) {
-    payload.description = description;
-    payload.descripcion = description;
-  } else {
-    payload.description = null;
-    payload.descripcion = null;
-  }
 
   return payload;
 }

--- a/app/api/admin/suppliers/strapi-helpers.ts
+++ b/app/api/admin/suppliers/strapi-helpers.ts
@@ -159,17 +159,10 @@ export function mapCategoryFromStrapi(node: unknown): Category | undefined {
     ? attributes.name
     : "";
 
-  const description = typeof attributes.description === "string"
-    ? attributes.description
-    : typeof attributes.descripcion === "string"
-    ? attributes.descripcion
-    : undefined;
-
   return {
     id,
     documentId,
     nombre,
-    description,
     ingredientes: [],
     ingredient_supplier_prices: [],
   };

--- a/components/sections/admin/ingredient-categories/IngredientCategoryForm.tsx
+++ b/components/sections/admin/ingredient-categories/IngredientCategoryForm.tsx
@@ -28,38 +28,21 @@ export function IngredientCategoryForm({
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="sm:col-span-1">
-          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="category-name">
-            Nombre <span className="text-red-500">*</span>
-          </label>
-          <input
-            id="category-name"
-            type="text"
-            value={form.nombre}
-            onChange={(event) =>
-              setForm((prev) => ({ ...prev, nombre: event.target.value }))
-            }
-            placeholder="Ej. Lácteos"
-            className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[#8B4513] focus:outline-none focus:ring-2 focus:ring-[#8B4513]/40"
-            required
-          />
-        </div>
-        <div className="sm:col-span-1">
-          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="category-description">
-            Descripción
-          </label>
-          <textarea
-            id="category-description"
-            value={form.description}
-            onChange={(event) =>
-              setForm((prev) => ({ ...prev, description: event.target.value }))
-            }
-            placeholder="Descripción opcional"
-            rows={3}
-            className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[#8B4513] focus:outline-none focus:ring-2 focus:ring-[#8B4513]/40"
-          />
-        </div>
+      <div>
+        <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="category-name">
+          Nombre <span className="text-red-500">*</span>
+        </label>
+        <input
+          id="category-name"
+          type="text"
+          value={form.nombre}
+          onChange={(event) =>
+            setForm((prev) => ({ ...prev, nombre: event.target.value }))
+          }
+          placeholder="Ej. Lácteos"
+          className="w-full rounded-xl border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[#8B4513] focus:outline-none focus:ring-2 focus:ring-[#8B4513]/40"
+          required
+        />
       </div>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">

--- a/components/sections/admin/ingredient-categories/IngredientCategoryTable.tsx
+++ b/components/sections/admin/ingredient-categories/IngredientCategoryTable.tsx
@@ -23,9 +23,6 @@ export function IngredientCategoryTable({
               Nombre
             </th>
             <th scope="col" className="px-5 py-3 text-left font-semibold">
-              Descripción
-            </th>
-            <th scope="col" className="px-5 py-3 text-left font-semibold">
               Ingredientes asociados
             </th>
             <th scope="col" className="px-5 py-3 text-center font-semibold">
@@ -37,7 +34,7 @@ export function IngredientCategoryTable({
           {categories.length === 0 ? (
             <tr>
               <td
-                colSpan={4}
+                colSpan={3}
                 className="px-5 py-6 text-center text-sm text-gray-500"
               >
                 No hay categorías cargadas todavía.
@@ -58,11 +55,6 @@ export function IngredientCategoryTable({
                 <tr key={rowKey} className="transition hover:bg-gray-50">
                   <td className="whitespace-nowrap px-5 py-4 font-medium">
                     {category.nombre || "Sin nombre"}
-                  </td>
-                  <td className="px-5 py-4 text-gray-600">
-                    {category.description && category.description.trim() !== ""
-                      ? category.description
-                      : "Sin descripción"}
                   </td>
                   <td className="px-5 py-4">
                     <span className="inline-flex items-center rounded-full bg-[#F7EDE2] px-3 py-1 text-xs font-medium text-[#8B4513]">

--- a/components/sections/admin/ingredient-categories/hooks/useIngredientCategoriesAdmin.ts
+++ b/components/sections/admin/ingredient-categories/hooks/useIngredientCategoriesAdmin.ts
@@ -10,12 +10,10 @@ export type CategoryFormState = {
   id?: number;
   documentId?: string;
   nombre: string;
-  description: string;
 };
 
 const EMPTY_FORM: CategoryFormState = {
   nombre: "",
-  description: "",
 };
 
 export function useIngredientCategoriesAdmin() {
@@ -44,11 +42,7 @@ export function useIngredientCategoriesAdmin() {
     return categories
       .filter((category) => {
         const name = category.nombre?.toLowerCase?.() ?? "";
-        const description = category.description?.toLowerCase?.() ?? "";
-        return (
-          name.includes(normalizedSearch) ||
-          (description ? description.includes(normalizedSearch) : false)
-        );
+        return name.includes(normalizedSearch);
       })
       .sort((a, b) =>
         (a.nombre ?? "").localeCompare(b.nombre ?? "", "es", { sensitivity: "base" })
@@ -77,7 +71,6 @@ export function useIngredientCategoriesAdmin() {
       id: category.id,
       documentId: category.documentId,
       nombre: category.nombre ?? "",
-      description: category.description ?? "",
     });
     setShowForm(true);
   };
@@ -111,7 +104,6 @@ export function useIngredientCategoriesAdmin() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           nombre: form.nombre,
-          description: form.description,
         }),
       });
 

--- a/types/categoria_ingrediente.ts
+++ b/types/categoria_ingrediente.ts
@@ -5,7 +5,6 @@ export type Category = {
   id: number;
   documentId: string;
   nombre: string;
-  description?: string;
   ingredientes: IngredientType[];
   ingredient_supplier_prices: IngredientSupplierPrice[];
 };


### PR DESCRIPTION
## Summary
- drop the optional description field from the ingredient category admin form and table so only the name is captured
- update the admin hook, API endpoints, Strapi mapper and shared types to stop reading or sending description data

## Testing
- npm run lint *(fails: existing lint violations in unrelated checkout, consulta de pedido, productos, recetas and other files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e934fcf883218e34c06385a86029