### PR TITLE
Add low stock alerts and supplier messaging

### DIFF
--- a/components/hooks/useLowStockIngredients.ts
+++ b/components/hooks/useLowStockIngredients.ts
@@ -1,0 +1,37 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { listIngredients } from "@/lib/admin/ingredients-api";
+import { isLowStock, LOW_STOCK_THRESHOLD } from "@/lib/inventory";
+
+interface UseLowStockOptions {
+  threshold?: number;
+  pageSize?: number;
+  enabled?: boolean;
+}
+
+export function useLowStockIngredients(options: UseLowStockOptions = {}) {
+  const threshold = options.threshold ?? LOW_STOCK_THRESHOLD;
+  const pageSize = options.pageSize ?? 200;
+  const enabled = options.enabled ?? true;
+
+  const query = useQuery({
+    queryKey: ["lowStockIngredients", { threshold, pageSize }],
+    queryFn: () => listIngredients({ page: 1, pageSize }),
+    staleTime: 1000 * 60,
+    gcTime: 1000 * 60 * 5,
+    enabled,
+  });
+
+  const lowStockIngredientes = useMemo(() => {
+    const items = query.data?.items ?? [];
+    return items
+      .filter((ingredient) => isLowStock(ingredient, threshold))
+      .sort((a, b) => (a.Stock ?? 0) - (b.Stock ?? 0));
+  }, [query.data, threshold]);
+
+  return {
+    lowStockIngredientes,
+    threshold,
+    ...query,
+  };
+}

--- a/components/sections/admin/ingredientes/IngredientesSection.tsx
+++ b/components/sections/admin/ingredientes/IngredientesSection.tsx
@@ -5,6 +5,7 @@ import IngredientFilters from "./IngredientFilters";
 import IngredientForm from "./IngredientForm";
 import IngredientTable from "./IngredientTable";
 import { useIngredientesAdmin } from "./hooks/useIngredientesAdmin";
+import { LowStockSummary } from "./LowStockSummary";
 
 export default function IngredientesSection() {
   const {
@@ -29,6 +30,8 @@ export default function IngredientesSection() {
     editIngrediente,
     deleteIngrediente,
     startNew,
+    lowStockIngredientes,
+    lowStockThreshold,
   } = useIngredientesAdmin();
 
   if (loading) {
@@ -67,6 +70,11 @@ export default function IngredientesSection() {
       {showForm && (
         <IngredientForm form={form} setForm={setForm} onSave={saveIngrediente} />
       )}
+
+      <LowStockSummary
+        ingredientes={lowStockIngredientes}
+        threshold={lowStockThreshold}
+      />
 
       <IngredientTable
         ingredientes={ingredientes}

--- a/components/sections/admin/ingredientes/LowStockSummary.tsx
+++ b/components/sections/admin/ingredientes/LowStockSummary.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import { IngredientType } from "@/types/ingredient";
+import { formatIngredientStockLabel } from "@/lib/inventory";
+
+interface LowStockSummaryProps {
+  ingredientes: IngredientType[];
+  threshold: number;
+}
+
+export function LowStockSummary({ ingredientes, threshold }: LowStockSummaryProps) {
+  const hasLowStock = ingredientes.length > 0;
+
+  if (!hasLowStock) {
+    return (
+      <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700 shadow-sm">
+        <div className="flex items-start gap-3">
+          <CheckCircle2 className="mt-0.5 h-5 w-5 text-emerald-500" />
+          <div className="space-y-1">
+            <p className="font-semibold text-emerald-900">
+              Stock al día
+            </p>
+            <p className="text-emerald-800/80">
+              Todos los ingredientes superan el umbral de {threshold} unidades.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 shadow-sm">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600" />
+        <div className="space-y-1">
+          <p className="font-semibold text-amber-900">
+            Ingredientes con stock crítico
+          </p>
+          <p className="text-amber-800/80">
+            Los siguientes ingredientes tienen stock menor o igual a {threshold}.
+          </p>
+        </div>
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {ingredientes.map((ingredient) => {
+          const numericStock = Number.isFinite(ingredient.Stock)
+            ? ingredient.Stock
+            : 0;
+          const isOutOfStock = numericStock <= 0;
+          const unit = ingredient.unidadMedida?.trim?.() ?? "";
+          const quantityLabel = isOutOfStock
+            ? "Sin stock"
+            : `${numericStock.toLocaleString("es-AR", {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: numericStock % 1 === 0 ? 0 : 2,
+              })}${unit ? ` ${unit}` : ""}`;
+
+          return (
+            <li
+              key={ingredient.documentId || ingredient.id || ingredient.ingredienteName}
+              className="rounded-xl border border-amber-200 bg-white/80 px-3 py-2 shadow-sm"
+            >
+              <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-medium text-amber-900">
+                    {ingredient.ingredienteName}
+                  </p>
+                  {ingredient.supplier?.name && (
+                    <p className="text-xs text-amber-700/80">
+                      Proveedor habitual: {ingredient.supplier.name}
+                    </p>
+                  )}
+                </div>
+                <div className="text-sm font-semibold">
+                  <span className={isOutOfStock ? "text-red-600" : "text-amber-800"}>
+                    {quantityLabel}
+                  </span>
+                </div>
+              </div>
+              <p className="mt-1 text-xs text-amber-700/70">
+                {formatIngredientStockLabel(ingredient)}
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/components/sections/admin/suppliers/SupplierTable.tsx
+++ b/components/sections/admin/suppliers/SupplierTable.tsx
@@ -1,12 +1,14 @@
 import { SupplierType } from "@/types/supplier";
 import { formatPrecioUnitario } from "@/lib/pricing/normalize";
-import { CirclePlus, Pencil, Trash2 } from "lucide-react";
+import { CirclePlus, Pencil, Send, Trash2 } from "lucide-react";
 
 interface SupplierTableProps {
   suppliers: SupplierType[];
   onEdit: (supplier: SupplierType) => void;
   onDelete: (supplier: SupplierType) => void;
   onAddPrice: (supplier: SupplierType) => void;
+  onSendMessage: (supplier: SupplierType) => void;
+  disableSendMessage?: boolean;
 }
 
 type CheapestEntry = { normalized: number | null; fallback: number | null };
@@ -14,7 +16,14 @@ type CheapestEntry = { normalized: number | null; fallback: number | null };
 const NORMALIZED_EPSILON = 1e-6;
 const PRICE_EPSILON = 0.01;
 
-export function SupplierTable({ suppliers, onEdit, onDelete, onAddPrice }: SupplierTableProps) {
+export function SupplierTable({
+  suppliers,
+  onEdit,
+  onDelete,
+  onAddPrice,
+  onSendMessage,
+  disableSendMessage = false,
+}: SupplierTableProps) {
   const cheapestPriceByIngredientId = new Map<number, CheapestEntry>();
   const collator = new Intl.Collator("es-ES", { sensitivity: "base" });
 
@@ -285,6 +294,20 @@ export function SupplierTable({ suppliers, onEdit, onDelete, onAddPrice }: Suppl
                   </td>
                   <td className="px-6 py-4">
                     <div className="flex items-center justify-center gap-4">
+                      <button
+                        onClick={() => onSendMessage(supplier)}
+                        className={`text-amber-600 transition hover:text-amber-800 ${
+                          disableSendMessage ? "cursor-not-allowed opacity-50 hover:text-amber-600" : ""
+                        }`}
+                        disabled={disableSendMessage}
+                        title={
+                          disableSendMessage
+                            ? "Cargando ingredientes con bajo stock"
+                            : "Enviar mensaje al proveedor"
+                        }
+                      >
+                        <Send className="h-5 w-5" />
+                      </button>
                       <button
                         onClick={() => onAddPrice(supplier)}
                         className="text-emerald-600 transition hover:text-emerald-800"

--- a/lib/inventory.ts
+++ b/lib/inventory.ts
@@ -1,0 +1,28 @@
+import { IngredientType } from "@/types/ingredient";
+
+export const LOW_STOCK_THRESHOLD = 5;
+
+export function isLowStock(
+  ingredient: IngredientType,
+  threshold: number = LOW_STOCK_THRESHOLD
+) {
+  const stockValue = typeof ingredient.Stock === "number" ? ingredient.Stock : 0;
+  return stockValue <= threshold;
+}
+
+export function formatIngredientStockLabel(ingredient: IngredientType) {
+  const stockValue = typeof ingredient.Stock === "number" ? ingredient.Stock : 0;
+  const safeStock = Number.isFinite(stockValue) ? stockValue : 0;
+  const unit = ingredient.unidadMedida?.trim?.() ?? "";
+  if (safeStock <= 0) {
+    return `${ingredient.ingredienteName} (sin stock)`;
+  }
+
+  const formattedQuantity = safeStock.toLocaleString("es-AR", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: safeStock % 1 === 0 ? 0 : 2,
+  });
+
+  const unitSuffix = unit ? ` ${unit}` : "";
+  return `${ingredient.ingredienteName} (${formattedQuantity}${unitSuffix})`;
+}


### PR DESCRIPTION
## Summary
- add inventory utilities and a low-stock hook for reuse across admin views
- surface a low-stock summary card on the ingredientes admin page
- enable sending/copying a prefilled low-stock message from the proveedores table

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d5eda5e58483218690c81b612903ce