### PR TITLE
Adjust low stock threshold and allow editing supplier message

### DIFF
--- a/components/sections/admin/ingredientes/IngredientTable.tsx
+++ b/components/sections/admin/ingredientes/IngredientTable.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { ArrowUpDown, Pencil, Trash2, AlertTriangle, Eye } from 'lucide-react';
 import { IngredientType } from '@/types/ingredient';
+import { LOW_STOCK_THRESHOLD } from '@/lib/inventory';
 import IngredientPricesModal from './IngredientPricesModal';
 
 interface Props {
@@ -64,7 +65,9 @@ export default function IngredientTable({ ingredientes, onEdit, onDelete, orderB
           {ingredientes.map(i => (
             <tr key={i.id} className="border-b last:border-none hover:bg-[#FFF8EC] transition">
               <td className="p-3 capitalize font-medium flex items-center gap-2">
-              {i.Stock <= 5 && <AlertTriangle className="h-4 w-4 text-red-600" />}
+                {typeof i.Stock === 'number' && i.Stock <= LOW_STOCK_THRESHOLD && (
+                  <AlertTriangle className="h-4 w-4 text-red-600" />
+                )}
                 <div className="flex flex-col">
                   <span>{i.ingredienteName}</span>
                   {i.ingredienteNameProducion && (

--- a/components/sections/admin/productos/ProductTable.tsx
+++ b/components/sections/admin/productos/ProductTable.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { ArrowUpDown, Pencil, Trash2, Check, AlertTriangle, Star, ImageOff } from "lucide-react";
 import { ProductType } from "@/types/product";
+import { LOW_STOCK_THRESHOLD } from "@/lib/inventory";
 
 interface Props {
   productos: ProductType[];
@@ -131,7 +132,8 @@ export default function ProductTable({ productos, onEdit, onDelete, orderBy, set
         <tbody>
           {productos.map((p) => {
             const url = getMainImageUrl(p);
-            const lowStock = typeof p.stock === "number" && p.stock <= 5;
+            const lowStock =
+              typeof p.stock === "number" && p.stock <= LOW_STOCK_THRESHOLD;
 
             return (
               <tr

--- a/components/sections/admin/productos/ProductosSection.tsx
+++ b/components/sections/admin/productos/ProductosSection.tsx
@@ -11,6 +11,7 @@ import { useProductAdmin } from "./hooks/useProductAdmin";
 import { useImageUpload } from "./hooks/useImageUpload";
 import { ProductType } from "@/types/product";
 import { toMediaURL } from "@/utils/media";
+import { LOW_STOCK_THRESHOLD } from "@/lib/inventory";
 
 
 const generateSlug = (text: string) =>
@@ -185,7 +186,9 @@ export default function ProductosSection() {
       .filter((p) =>
         filterUnidad === "all" ? true : p.unidadMedida === filterUnidad
       )
-      .filter((p) => (filterLowStock ? (p.stock || 0) <= 5 : true));
+      .filter((p) =>
+        filterLowStock ? (p.stock ?? 0) <= LOW_STOCK_THRESHOLD : true
+      );
   }, [products, search, filterOffer, filterActive, filterUnidad, filterLowStock]);
 
   const sorted = useMemo(() => {

--- a/components/sections/admin/suppliers/SuppliersSection.tsx
+++ b/components/sections/admin/suppliers/SuppliersSection.tsx
@@ -67,12 +67,29 @@ export default function SuppliersSection() {
         return;
       }
 
-      const message = `Hola buenas, ¿cómo va ${supplier.name}? Necesito ${lowStockListForMessage}.`;
+      const defaultMessage = `Hola, ¿cómo va ${supplier.name}? Te quería encargar ${lowStockListForMessage}.`;
+
+      let finalMessage = defaultMessage;
+
+      if (typeof window !== "undefined") {
+        const editedMessage = window.prompt(
+          "Revisá y editá el mensaje antes de enviarlo:",
+          defaultMessage
+        );
+
+        if (editedMessage === null) {
+          toast.info("Mensaje cancelado.");
+          return;
+        }
+
+        finalMessage =
+          editedMessage.trim().length > 0 ? editedMessage : defaultMessage;
+      }
 
       let copiedToClipboard = false;
       if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
         try {
-          await navigator.clipboard.writeText(message);
+          await navigator.clipboard.writeText(finalMessage);
           copiedToClipboard = true;
           toast.success("Mensaje copiado al portapapeles.");
         } catch (clipboardError) {
@@ -81,13 +98,16 @@ export default function SuppliersSection() {
       }
 
       if (!copiedToClipboard && typeof window !== "undefined") {
-        window.prompt("Copiá el mensaje para enviarlo al proveedor:", message);
+        window.prompt(
+          "Copiá el mensaje para enviarlo al proveedor:",
+          finalMessage
+        );
       }
 
       if (typeof window !== "undefined" && supplier.phone) {
         const sanitizedPhone = supplier.phone.replace(/\D+/g, "");
         if (sanitizedPhone) {
-          const whatsappUrl = `https://wa.me/${sanitizedPhone}?text=${encodeURIComponent(message)}`;
+          const whatsappUrl = `https://wa.me/${sanitizedPhone}?text=${encodeURIComponent(finalMessage)}`;
           window.open(whatsappUrl, "_blank", "noopener,noreferrer");
         }
       }

--- a/lib/inventory.ts
+++ b/lib/inventory.ts
@@ -1,6 +1,6 @@
 import { IngredientType } from "@/types/ingredient";
 
-export const LOW_STOCK_THRESHOLD = 5;
+export const LOW_STOCK_THRESHOLD = -2;
 
 export function isLowStock(
   ingredient: IngredientType,


### PR DESCRIPTION
## Summary
- lower the shared low stock threshold to -2 and reuse it across ingredient and product admin views
- prompt admins with an editable default WhatsApp message before contacting suppliers and reuse the final message for clipboard/links

## Testing
- npm run lint *(fails: repository already contains numerous pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f0b440108321a5394bdde2ca40d5