### PR TITLE
Fix low stock threshold

### DIFF
--- a/lib/inventory.ts
+++ b/lib/inventory.ts
@@ -1,6 +1,6 @@
 import { IngredientType } from "@/types/ingredient";
 
-export const LOW_STOCK_THRESHOLD = -2;
+export const LOW_STOCK_THRESHOLD = 2;
 
 export function isLowStock(
   ingredient: IngredientType,


### PR DESCRIPTION
## Summary
- update the low stock threshold constant to treat values below or equal to 2 as low stock

## Testing
- `npm run lint` *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f26e4de883218fc2d1b1a047f447