### PR TITLE
Display production names for ingredients in product admin views

### DIFF
--- a/components/sections/admin/productos/ProductForm.tsx
+++ b/components/sections/admin/productos/ProductForm.tsx
@@ -346,6 +346,7 @@ export default function ProductForm({
                 }}
               />
               {ing.ingredienteName}
+              {ing.ingredienteNameProducion ? ` (${ing.ingredienteNameProducion})` : ""}
             </label>
           ))}
         </div>

--- a/components/sections/admin/productos/ProductTable.tsx
+++ b/components/sections/admin/productos/ProductTable.tsx
@@ -218,12 +218,10 @@ export default function ProductTable({ productos, onEdit, onDelete, orderBy, set
                         >
                           <span className="block font-medium capitalize text-[#4A2E15]">
                             {ingrediente.ingredienteName}
+                            {ingrediente.ingredienteNameProducion
+                              ? ` (${ingrediente.ingredienteNameProducion})`
+                              : ""}
                           </span>
-                          {ingrediente.ingredienteNameProducion && (
-                            <span className="block text-[11px] font-normal text-[#8a6a45]">
-                              {ingrediente.ingredienteNameProducion}
-                            </span>
-                          )}
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
## Summary
- append each ingredient's production name in parentheses when selecting related ingredients in the product form
- show the production name alongside the ingredient name in the product table list

## Testing
- npm run lint *(fails: pre-existing lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d5fb09a79c8321844ac65688f6b4f0