### PR TITLE
Add fabricación admin management UI and API bridge

### DIFF
--- a/app/admin/fabricacion/page.tsx
+++ b/app/admin/fabricacion/page.tsx
@@ -1,0 +1,13 @@
+import dynamic from 'next/dynamic';
+
+const FabricacionSection = dynamic(() => import('@/components/sections/admin/fabricacion/FabricacionSection'), {
+  ssr: false,
+});
+
+export default function FabricacionPage() {
+  return (
+    <div className="space-y-6">
+      <FabricacionSection />
+    </div>
+  );
+}

--- a/app/api/admin/fabricacions/[id]/recalculate/route.ts
+++ b/app/api/admin/fabricacions/[id]/recalculate/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { mapFabricacionFromStrapi, type StrapiResponse, type UnknownRecord } from '../../helpers';
+import { strapiFetch } from '../../../suppliers/strapi-helpers';
+
+type RouteContext = {
+  params: { id: string };
+};
+
+export async function POST(_req: NextRequest, context: RouteContext) {
+  const id = context.params.id;
+  try {
+    const res = await strapiFetch(`/api/fabricacions/${id}/recalculate`, { method: 'POST' });
+    const json = (await res.json().catch(() => ({}))) as StrapiResponse | UnknownRecord;
+    if (!res.ok) {
+      const errorRecord = json as UnknownRecord;
+      const message =
+        (errorRecord?.error && typeof (errorRecord.error as UnknownRecord)?.message === 'string'
+          ? String((errorRecord.error as UnknownRecord).message)
+          : 'Error recalculando costos');
+      return NextResponse.json({ ok: false, message }, { status: res.status || 500 });
+    }
+    const responseData = (json as StrapiResponse).data ?? json;
+    const item = mapFabricacionFromStrapi(responseData);
+    if (!item) {
+      return NextResponse.json({ ok: false, message: 'Respuesta inválida del servidor' }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true, item });
+  } catch (error) {
+    console.error('[fabricacions][POST:recalculate] error', error);
+    return NextResponse.json({ ok: false, message: 'Error inesperado' }, { status: 500 });
+  }
+}

--- a/app/api/admin/fabricacions/[id]/route.ts
+++ b/app/api/admin/fabricacions/[id]/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  mapFabricacionFromStrapi,
+  sanitizeFabricacionPayload,
+  toStrapiPayload,
+  type StrapiResponse,
+  type UnknownRecord,
+} from '../helpers';
+import { strapiFetch } from '../../suppliers/strapi-helpers';
+
+type RouteContext = {
+  params: { id: string };
+};
+
+function buildDetailPath(id: string) {
+  return `/api/fabricacions/${id}?populate[0]=product&populate[1]=lineas.ingredient`;
+}
+
+export async function GET(_req: NextRequest, context: RouteContext) {
+  const id = context.params.id;
+  try {
+    const res = await strapiFetch(buildDetailPath(id));
+    const json = (await res.json().catch(() => ({}))) as StrapiResponse;
+    if (!res.ok) {
+      const errorRecord = json as UnknownRecord;
+      const message =
+        (errorRecord?.error && typeof (errorRecord.error as UnknownRecord)?.message === 'string'
+          ? String((errorRecord.error as UnknownRecord).message)
+          : 'Error obteniendo fabricación');
+      return NextResponse.json({ ok: false, message }, { status: res.status || 500 });
+    }
+    const item = mapFabricacionFromStrapi(json.data);
+    if (!item) {
+      return NextResponse.json({ ok: false, message: 'Fabricación no encontrada' }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, item });
+  } catch (error) {
+    console.error('[fabricacions][GET:id] error', error);
+    return NextResponse.json({ ok: false, message: 'Error inesperado' }, { status: 500 });
+  }
+}
+
+export async function PUT(req: NextRequest, context: RouteContext) {
+  const id = context.params.id;
+  try {
+    const payload = sanitizeFabricacionPayload(await req.json());
+    const res = await strapiFetch(`/api/fabricacions/${id}?populate[0]=product&populate[1]=lineas.ingredient`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data: toStrapiPayload(payload) }),
+    });
+    const json = (await res.json().catch(() => ({}))) as StrapiResponse;
+    if (!res.ok) {
+      const errorRecord = json as UnknownRecord;
+      const message =
+        (errorRecord?.error && typeof (errorRecord.error as UnknownRecord)?.message === 'string'
+          ? String((errorRecord.error as UnknownRecord).message)
+          : 'Error actualizando fabricación');
+      return NextResponse.json({ ok: false, message, details: json }, { status: res.status || 500 });
+    }
+    const item = mapFabricacionFromStrapi(json.data);
+    if (!item) {
+      return NextResponse.json({ ok: false, message: 'Respuesta inválida del servidor' }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true, item });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error inesperado';
+    console.error('[fabricacions][PUT:id] error', error);
+    return NextResponse.json({ ok: false, message }, { status: 400 });
+  }
+}
+
+export async function DELETE(_req: NextRequest, context: RouteContext) {
+  const id = context.params.id;
+  try {
+    const res = await strapiFetch(`/api/fabricacions/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const json = (await res.json().catch(() => ({}))) as UnknownRecord;
+      const message =
+        (json?.error && typeof (json.error as UnknownRecord)?.message === 'string'
+          ? String((json.error as UnknownRecord).message)
+          : 'Error eliminando fabricación');
+      return NextResponse.json({ ok: false, message }, { status: res.status || 500 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[fabricacions][DELETE:id] error', error);
+    return NextResponse.json({ ok: false, message: 'Error inesperado' }, { status: 500 });
+  }
+}

--- a/app/api/admin/fabricacions/helpers.ts
+++ b/app/api/admin/fabricacions/helpers.ts
@@ -1,0 +1,335 @@
+import {
+  FabricacionDoc,
+  FabricacionListMeta,
+  FabricacionPayload,
+  FabricacionPayloadLine,
+  FabricacionSnapshot,
+  IngredienteLite,
+  ProductLite,
+} from '@/types/fabricacion';
+import { strapiFetch } from '../suppliers/strapi-helpers';
+
+export type UnknownRecord = Record<string, unknown>;
+
+export type StrapiResponse<T = unknown> = {
+  data?: T;
+  meta?: UnknownRecord;
+};
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (value === null || value === undefined) return fallback;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function toNullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string' && value.trim() === '') return null;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+function toStringValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function toPositiveNumber(value: unknown, fallback = 0): number {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return num < 0 ? fallback : num;
+}
+
+function toDateOrNull(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const date = new Date(trimmed);
+    return Number.isNaN(date.getTime()) ? trimmed : date.toISOString();
+  }
+  if (value instanceof Date) return value.toISOString();
+  return null;
+}
+
+function unwrapData(node: unknown): UnknownRecord | null {
+  if (!isRecord(node)) return null;
+  if (isRecord(node.data)) return node.data as UnknownRecord;
+  return node as UnknownRecord;
+}
+
+function getAttributes(node: unknown): UnknownRecord | null {
+  const base = unwrapData(node);
+  if (!base) return null;
+  if (isRecord(base.attributes)) return { ...base.attributes, id: base.id ?? (base.attributes as UnknownRecord).id };
+  return base;
+}
+
+function mapProductLite(node: unknown): ProductLite | null {
+  const attrs = getAttributes(node);
+  if (!attrs) return null;
+  const id = toNumber(attrs.id, 0);
+  if (!id) return null;
+  const documentId = typeof attrs.documentId === 'string' ? attrs.documentId : undefined;
+  const productName = typeof attrs.productName === 'string' ? attrs.productName : typeof attrs.nombre === 'string' ? attrs.nombre : '';
+  const slug = typeof attrs.slug === 'string' ? attrs.slug : undefined;
+  const price = toNullableNumber(attrs.price ?? attrs.precio);
+  return { id, documentId, productName, slug, price };
+}
+
+function mapIngredientLite(node: unknown): IngredienteLite | null {
+  const attrs = getAttributes(node);
+  if (!attrs) return null;
+  const id = toNumber(attrs.id, 0);
+  if (!id) return null;
+  const documentId = typeof attrs.documentId === 'string' ? attrs.documentId : undefined;
+  const ingredienteName =
+    typeof attrs.ingredienteName === 'string'
+      ? attrs.ingredienteName
+      : typeof attrs.nombre === 'string'
+      ? attrs.nombre
+      : typeof attrs.name === 'string'
+      ? attrs.name
+      : '';
+  const unidadMedida = typeof attrs.unidadMedida === 'string' ? attrs.unidadMedida : undefined;
+  const price = toNullableNumber(attrs.precio ?? attrs.price);
+  return { id, documentId, ingredienteName, unidadMedida, price };
+}
+
+function mapLine(node: unknown) {
+  if (!isRecord(node)) return null;
+  const ingredient = mapIngredientLite(node.ingredient);
+  const cantidad = toNumber(node.cantidad, 0);
+  const unidad = toStringValue(node.unidad).trim();
+  if (!unidad) return null;
+  const mermaPct = toNullableNumber(node.mermaPct);
+  const nota = typeof node.nota === 'string' ? node.nota : null;
+  const idRaw = toNullableNumber(node.id);
+  return {
+    id: idRaw ?? undefined,
+    ingredient,
+    cantidad,
+    unidad,
+    mermaPct,
+    nota,
+  };
+}
+
+function mapSnapshot(attrs: UnknownRecord): FabricacionSnapshot {
+  return {
+    ingredientesCostoTotal: toNullableNumber(attrs.ingredientesCostoTotal),
+    costoTotalBatch: toNullableNumber(attrs.costoTotalBatch),
+    costoUnitario: toNullableNumber(attrs.costoUnitario),
+    precioSugerido: toNullableNumber(attrs.precioSugerido),
+    margenRealPct: toNullableNumber(attrs.margenRealPct),
+    lastCalculatedAt: toDateOrNull(attrs.lastCalculatedAt),
+  };
+}
+
+export function mapFabricacionFromStrapi(entry: unknown): FabricacionDoc | null {
+  const attrs = getAttributes(entry);
+  if (!attrs) return null;
+  const id = toNumber(attrs.id, 0);
+  if (!id) return null;
+  const documentId = typeof attrs.documentId === 'string' ? attrs.documentId : undefined;
+  const nombre = typeof attrs.nombre === 'string' ? attrs.nombre : '';
+  const batchSize = Math.max(1, toNumber(attrs.batchSize, 1));
+  const mermaPct = toNullableNumber(attrs.mermaPct);
+  const costoManoObra = toNullableNumber(attrs.costoManoObra);
+  const costoEmpaque = toNullableNumber(attrs.costoEmpaque);
+  const overheadPct = toNullableNumber(attrs.overheadPct);
+  const margenObjetivoPct = toNullableNumber(attrs.margenObjetivoPct);
+  const updatedAt = toDateOrNull(attrs.updatedAt);
+  const publishedAt = toDateOrNull(attrs.publishedAt);
+  const createdAt = toDateOrNull(attrs.createdAt);
+
+  const lineasSource = Array.isArray(attrs.lineas)
+    ? attrs.lineas
+    : isRecord(attrs.lineas) && Array.isArray((attrs.lineas as UnknownRecord).data)
+    ? ((attrs.lineas as UnknownRecord).data as unknown[])
+    : [];
+  const lineas = lineasSource
+    .map((line) => mapLine(line))
+    .filter((line): line is NonNullable<ReturnType<typeof mapLine>> => Boolean(line));
+
+  const snapshots = mapSnapshot(attrs);
+  const lastCalculatedAt = snapshots.lastCalculatedAt ? new Date(snapshots.lastCalculatedAt) : null;
+  const updatedDate = updatedAt ? new Date(updatedAt) : null;
+  const needsRecalculation = !lastCalculatedAt || (updatedDate && lastCalculatedAt && updatedDate > lastCalculatedAt);
+
+  return {
+    id,
+    documentId,
+    nombre,
+    product: mapProductLite(attrs.product),
+    batchSize,
+    mermaPct,
+    costoManoObra,
+    costoEmpaque,
+    overheadPct,
+    margenObjetivoPct,
+    lineas,
+    snapshots,
+    updatedAt,
+    publishedAt,
+    createdAt,
+    needsRecalculation,
+  };
+}
+
+export function extractMeta(meta: UnknownRecord | undefined): FabricacionListMeta {
+  const pagination = isRecord(meta?.pagination) ? (meta!.pagination as UnknownRecord) : {};
+  return {
+    page: toNumber(pagination.page, 1),
+    pageSize: toNumber(pagination.pageSize, 10),
+    pageCount: toNumber(pagination.pageCount, 1),
+    total: toNumber(pagination.total, 0),
+  };
+}
+
+export function buildListPath(searchParams: URLSearchParams) {
+  const page = Number(searchParams.get('page') || '1');
+  const pageSize = Number(searchParams.get('pageSize') || '10');
+  const search = (searchParams.get('search') || '').trim();
+  const status = (searchParams.get('status') || 'all') as 'all' | 'draft' | 'published';
+  const productId = (searchParams.get('productId') || '').trim();
+
+  const sp = new URLSearchParams();
+  sp.set('populate[0]', 'product');
+  sp.set('populate[1]', 'lineas.ingredient');
+  sp.set('pagination[page]', String(page));
+  sp.set('pagination[pageSize]', String(pageSize));
+  sp.set('sort[0]', 'updatedAt:desc');
+
+  if (search) sp.set('filters[nombre][$containsi]', search);
+  if (productId) sp.set('filters[product][id][$eq]', productId);
+  if (status === 'draft') sp.set('filters[publishedAt][$null]', 'true');
+  if (status === 'published') sp.set('filters[publishedAt][$notNull]', 'true');
+
+  return `/api/fabricacions?${sp.toString()}`;
+}
+
+function cleanUndefined<T extends UnknownRecord>(data: T): T {
+  const entries = Object.entries(data).filter(([, value]) => value !== undefined);
+  return Object.fromEntries(entries) as T;
+}
+
+export function toStrapiPayload(payload: FabricacionPayload) {
+  const base = {
+    nombre: payload.nombre,
+    batchSize: payload.batchSize,
+    mermaPct: payload.mermaPct ?? 0,
+    costoManoObra: payload.costoManoObra ?? 0,
+    costoEmpaque: payload.costoEmpaque ?? 0,
+    overheadPct: payload.overheadPct ?? 0,
+    margenObjetivoPct: payload.margenObjetivoPct ?? 0,
+    product: payload.productId ?? null,
+    lineas: payload.lineas.map((line) =>
+      cleanUndefined({
+        id: line.id,
+        ingredient: line.ingredientId ?? null,
+        cantidad: line.cantidad,
+        unidad: line.unidad,
+        mermaPct: line.mermaPct ?? 0,
+        nota: line.nota ?? null,
+      }),
+    ),
+  };
+  return cleanUndefined(base);
+}
+
+export async function fetchFabricacionFromStrapi(path: string) {
+  const res = await strapiFetch(path);
+  const json = (await res.json()) as StrapiResponse;
+  return { res, json };
+}
+
+function ensureLinePayload(line: FabricacionPayloadLine, index: number): FabricacionPayloadLine {
+  if (!line.ingredientId || line.ingredientId <= 0) {
+    throw new Error(`La línea ${index + 1} debe tener un ingrediente`);
+  }
+  if (!Number.isFinite(line.cantidad) || line.cantidad <= 0) {
+    throw new Error(`La línea ${index + 1} debe tener una cantidad válida`);
+  }
+  if (!line.unidad || line.unidad.trim() === '') {
+    throw new Error(`La línea ${index + 1} debe tener una unidad`);
+  }
+  const normalized: FabricacionPayloadLine = {
+    id: line.id,
+    ingredientId: line.ingredientId,
+    cantidad: Math.max(0, Number(line.cantidad)),
+    unidad: line.unidad.trim(),
+    mermaPct:
+      line.mermaPct === null || line.mermaPct === undefined
+        ? 0
+        : Math.max(0, Number(line.mermaPct)),
+    nota: line.nota?.trim() ? line.nota.trim() : null,
+  };
+  return normalized;
+}
+
+export function sanitizeFabricacionPayload(input: unknown): FabricacionPayload {
+  if (!isRecord(input)) {
+    throw new Error('Datos de fabricación inválidos');
+  }
+  const nombre = toStringValue(input.nombre).trim();
+  if (!nombre) throw new Error('El nombre es obligatorio');
+
+  const batchSizeRaw = Number(input.batchSize ?? 1);
+  const batchSize = Number.isFinite(batchSizeRaw) && batchSizeRaw >= 1 ? batchSizeRaw : 1;
+
+  const productIdValue = input.productId;
+  const productId =
+    productIdValue === null || productIdValue === undefined
+      ? null
+      : toPositiveNumber(productIdValue, 0) || null;
+
+  const mermaPct = input.mermaPct === undefined ? undefined : Math.max(0, Number(input.mermaPct) || 0);
+  const costoManoObra = input.costoManoObra === undefined ? undefined : Math.max(0, Number(input.costoManoObra) || 0);
+  const costoEmpaque = input.costoEmpaque === undefined ? undefined : Math.max(0, Number(input.costoEmpaque) || 0);
+  const overheadPct = input.overheadPct === undefined ? undefined : Math.max(0, Number(input.overheadPct) || 0);
+  const margenObjetivoPct =
+    input.margenObjetivoPct === undefined ? undefined : Math.max(0, Number(input.margenObjetivoPct) || 0);
+
+  const lineasInput = Array.isArray(input.lineas) ? input.lineas : [];
+  if (!lineasInput.length) {
+    throw new Error('Debe ingresar al menos una línea de ingrediente');
+  }
+
+  const lineas = lineasInput.map((line, index) => {
+    if (!isRecord(line)) {
+      throw new Error(`Línea ${index + 1} inválida`);
+    }
+    const ingredientId = toPositiveNumber(line.ingredientId ?? (line.ingredient as UnknownRecord)?.id, 0);
+    const cantidad = Number(line.cantidad);
+    const unidad = toStringValue(line.unidad).trim();
+    const merma = line.mermaPct === undefined ? undefined : Number(line.mermaPct);
+    const nota = typeof line.nota === 'string' ? line.nota : null;
+    const payloadLine: FabricacionPayloadLine = {
+      id: toNullableNumber(line.id) ?? undefined,
+      ingredientId,
+      cantidad,
+      unidad,
+      mermaPct: merma ?? undefined,
+      nota,
+    };
+    return ensureLinePayload(payloadLine, index);
+  });
+
+  return {
+    nombre,
+    productId,
+    batchSize,
+    mermaPct,
+    costoManoObra,
+    costoEmpaque,
+    overheadPct,
+    margenObjetivoPct,
+    lineas,
+  };
+}

--- a/app/api/admin/fabricacions/products/route.ts
+++ b/app/api/admin/fabricacions/products/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ProductLite } from '@/types/fabricacion';
+import { strapiFetch } from '../../suppliers/strapi-helpers';
+import { type UnknownRecord } from '../helpers';
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null;
+}
+
+function mapProduct(node: unknown): ProductLite | null {
+  if (!isRecord(node)) return null;
+  const attributes = isRecord(node.attributes) ? node.attributes : node;
+  const id = typeof node.id === 'number' ? node.id : typeof attributes.id === 'number' ? attributes.id : null;
+  if (!id) return null;
+  const documentId = typeof attributes.documentId === 'string' ? attributes.documentId : undefined;
+  const productNameValue =
+    typeof attributes.productName === 'string'
+      ? attributes.productName
+      : typeof attributes.name === 'string'
+      ? attributes.name
+      : '';
+  const productName = productNameValue.trim();
+  if (!productName) return null;
+  const priceRaw = attributes.price ?? attributes.precio;
+  const price = typeof priceRaw === 'number' ? priceRaw : Number(priceRaw);
+  const slug = typeof attributes.slug === 'string' ? attributes.slug : undefined;
+  return { id, documentId, productName, slug, price: Number.isFinite(price) ? price : null };
+}
+
+export async function GET(req: NextRequest) {
+  const q = (req.nextUrl.searchParams.get('q') || '').trim();
+  const page = Number(req.nextUrl.searchParams.get('page') || '1');
+  const pageSize = Number(req.nextUrl.searchParams.get('pageSize') || '20');
+
+  const sp = new URLSearchParams();
+  sp.set('fields[0]', 'id');
+  sp.set('fields[1]', 'documentId');
+  sp.set('fields[2]', 'productName');
+  sp.set('fields[3]', 'slug');
+  sp.set('fields[4]', 'price');
+  sp.set('filters[active][$eq]', 'true');
+  if (q) sp.set('filters[productName][$containsi]', q);
+  sp.set('pagination[page]', String(page));
+  sp.set('pagination[pageSize]', String(pageSize));
+  sp.set('sort[0]', 'productName:asc');
+
+  try {
+    const res = await strapiFetch(`/api/products?${sp.toString()}`);
+    const json = (await res.json().catch(() => ({}))) as UnknownRecord;
+    if (!res.ok) {
+      const errorRecord = json as UnknownRecord;
+      const message =
+        (errorRecord?.error && typeof (errorRecord.error as UnknownRecord)?.message === 'string'
+          ? String((errorRecord.error as UnknownRecord).message)
+          : 'Error obteniendo productos');
+      return NextResponse.json({ ok: false, message }, { status: res.status || 500 });
+    }
+    const data = Array.isArray((json as { data?: unknown[] })?.data) ? ((json as { data?: unknown[] }).data as unknown[]) : [];
+    const items = data.map(mapProduct).filter((item): item is ProductLite => Boolean(item));
+    return NextResponse.json({ ok: true, items });
+  } catch (error) {
+    console.error('[fabricacions][products] error', error);
+    return NextResponse.json({ ok: false, message: 'Error inesperado' }, { status: 500 });
+  }
+}

--- a/app/api/admin/fabricacions/route.ts
+++ b/app/api/admin/fabricacions/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  buildListPath,
+  extractMeta,
+  fetchFabricacionFromStrapi,
+  mapFabricacionFromStrapi,
+  sanitizeFabricacionPayload,
+  toStrapiPayload,
+  type StrapiResponse,
+  type UnknownRecord,
+} from './helpers';
+import { strapiFetch } from '../suppliers/strapi-helpers';
+
+export async function GET(req: NextRequest) {
+  try {
+    const path = buildListPath(req.nextUrl.searchParams);
+    const { res, json } = await fetchFabricacionFromStrapi(path);
+    if (!res.ok) {
+      const errorRecord = json as UnknownRecord;
+      const message =
+        (errorRecord?.error && typeof (errorRecord.error as UnknownRecord)?.message === 'string'
+          ? String((errorRecord.error as UnknownRecord).message)
+          : 'Error obteniendo fabricaciones');
+      return NextResponse.json({ ok: false, message }, { status: res.status || 500 });
+    }
+    const data = Array.isArray(json?.data) ? (json?.data as unknown[]) : [];
+    const items = data
+      .map((entry) => mapFabricacionFromStrapi(entry))
+      .filter((item): item is NonNullable<ReturnType<typeof mapFabricacionFromStrapi>> => Boolean(item));
+    const meta = extractMeta(json?.meta as UnknownRecord | undefined);
+    return NextResponse.json({ ok: true, items, meta });
+  } catch (error) {
+    console.error('[fabricacions][GET] unexpected error', error);
+    return NextResponse.json({ ok: false, message: 'Error inesperado' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = sanitizeFabricacionPayload(await req.json());
+    const body = { data: toStrapiPayload(payload) };
+    const path = '/api/fabricacions?populate[0]=product&populate[1]=lineas.ingredient';
+    const res = await strapiFetch(path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json().catch(() => ({}))) as StrapiResponse;
+    if (!res.ok) {
+      const errorRecord = json as UnknownRecord;
+      const message =
+        (errorRecord?.error && typeof (errorRecord.error as UnknownRecord)?.message === 'string'
+          ? String((errorRecord.error as UnknownRecord).message)
+          : 'Error creando fabricación');
+      return NextResponse.json({ ok: false, message, details: json }, { status: res.status || 500 });
+    }
+    const item = mapFabricacionFromStrapi(json.data);
+    if (!item) {
+      return NextResponse.json({ ok: false, message: 'Respuesta inválida del servidor' }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true, item }, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Error inesperado';
+    console.error('[fabricacions][POST] error', error);
+    return NextResponse.json({ ok: false, message }, { status: 400 });
+  }
+}

--- a/components/sections/admin/fabricacion/ComputedSnapshot.tsx
+++ b/components/sections/admin/fabricacion/ComputedSnapshot.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { FabricacionSnapshot } from '@/types/fabricacion';
+
+const currencyFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat('es-AR', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const dateFormatter = new Intl.DateTimeFormat('es-AR', { dateStyle: 'short', timeStyle: 'short' });
+
+type Props = {
+  snapshot?: FabricacionSnapshot | null;
+  productPrice?: number | null;
+};
+
+function formatCurrency(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—';
+  return currencyFormatter.format(value);
+}
+
+function formatPercent(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—';
+  return `${percentFormatter.format(value)}%`;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return dateFormatter.format(parsed);
+}
+
+export default function ComputedSnapshot({ snapshot, productPrice }: Props) {
+  return (
+    <div className="rounded-2xl bg-[#fff7ee] p-4">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-[#5A3E1B]">Costos calculados</h3>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <Metric label="Costo total ingredientes" value={formatCurrency(snapshot?.ingredientesCostoTotal ?? null)} />
+        <Metric label="Costo total por batch" value={formatCurrency(snapshot?.costoTotalBatch ?? null)} />
+        <Metric label="Costo unitario" value={formatCurrency(snapshot?.costoUnitario ?? null)} />
+        <Metric label="Precio sugerido" value={formatCurrency(snapshot?.precioSugerido ?? null)} />
+        <Metric label="Margen real" value={productPrice ? formatPercent(snapshot?.margenRealPct ?? null) : '—'} />
+        <Metric label="Último cálculo" value={formatDate(snapshot?.lastCalculatedAt ?? null)} />
+      </div>
+      <p className="mt-2 text-xs text-[#8c6d4c]">
+        Estos valores se actualizan cuando presionás “Recalcular costos”.
+      </p>
+    </div>
+  );
+}
+
+type MetricProps = {
+  label: string;
+  value: string;
+};
+
+function Metric({ label, value }: MetricProps) {
+  return (
+    <div className="flex flex-col rounded-xl border border-[#f0dcc3] bg-white px-3 py-2">
+      <span className="text-xs font-medium uppercase text-[#a57c52]">{label}</span>
+      <span className="text-sm font-semibold text-[#5A3E1B]">{value}</span>
+    </div>
+  );
+}

--- a/components/sections/admin/fabricacion/FabricacionFilters.tsx
+++ b/components/sections/admin/fabricacion/FabricacionFilters.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useMemo, useState } from 'react';
+import AsyncSelect from 'react-select/async';
+import { useDebouncedCallback } from 'use-debounce';
+import type { FabricacionFiltersState } from '@/types/fabricacion';
+import { fetchProductOptions, type ProductOption } from './product-options';
+
+type Props = {
+  filters: FabricacionFiltersState;
+  onSearchChange: (value: string) => void;
+  onStatusChange: (value: FabricacionFiltersState['status']) => void;
+  onProductChange: (value: number | null) => void;
+  onReset: () => void;
+};
+
+export default function FabricacionFilters({ filters, onSearchChange, onStatusChange, onProductChange, onReset }: Props) {
+  const [searchValue, setSearchValue] = useState(filters.search);
+  const [productOption, setProductOption] = useState<ProductOption | null>(null);
+
+  useEffect(() => {
+    setSearchValue(filters.search);
+  }, [filters.search]);
+
+  useEffect(() => {
+    if (!filters.productId) {
+      setProductOption(null);
+    }
+  }, [filters.productId]);
+
+  const debouncedSearch = useDebouncedCallback((value: string) => {
+    onSearchChange(value);
+  }, 400);
+
+  const loadOptions = useMemo(() => (inputValue: string) => fetchProductOptions(inputValue.trim()), []);
+
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="grid flex-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-semibold text-[#5A3E1B]">Buscar por nombre</label>
+          <input
+            type="text"
+            value={searchValue}
+            onChange={(event) => {
+              const value = event.target.value;
+              setSearchValue(value);
+              debouncedSearch(value);
+            }}
+            placeholder="Ej. Salsa fileto"
+            className="w-full rounded-lg border border-[#e6cdb0] bg-[#fff7ee] px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-semibold text-[#5A3E1B]">Producto asociado</label>
+          <AsyncSelect
+            cacheOptions
+            loadOptions={loadOptions}
+            defaultOptions
+            classNamePrefix="fabricacion-select"
+            value={productOption}
+            onChange={(option) => {
+              const next = option ? (option as ProductOption) : null;
+              setProductOption(next);
+              onProductChange(next ? next.value : null);
+            }}
+            isClearable
+            placeholder="Buscar producto..."
+            styles={{
+              control: (base) => ({
+                ...base,
+                backgroundColor: '#fff7ee',
+                borderColor: '#e6cdb0',
+                borderRadius: 12,
+                minHeight: 40,
+              }),
+              menu: (base) => ({ ...base, zIndex: 20 }),
+            }}
+            noOptionsMessage={() => 'Sin resultados'}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-sm font-semibold text-[#5A3E1B]">Estado</label>
+          <select
+            value={filters.status}
+            onChange={(event) => onStatusChange(event.target.value as FabricacionFiltersState['status'])}
+            className="w-full rounded-lg border border-[#e6cdb0] bg-[#fff7ee] px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+          >
+            <option value="all">Todos</option>
+            <option value="published">Publicados</option>
+            <option value="draft">Borradores</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <button
+          type="button"
+          onClick={onReset}
+          className="rounded-xl border border-amber-400 px-4 py-2 text-sm font-medium text-amber-700 transition hover:bg-amber-50"
+        >
+          Limpiar filtros
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/admin/fabricacion/FabricacionForm.tsx
+++ b/components/sections/admin/fabricacion/FabricacionForm.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import AsyncSelect from 'react-select/async';
+import { useDebouncedCallback } from 'use-debounce';
+import type { FabricacionDoc, FabricacionPayload } from '@/types/fabricacion';
+import LineaEditor from './LineaEditor';
+import ComputedSnapshot from './ComputedSnapshot';
+import RecalculateButton from './RecalculateButton';
+import { fetchProductOptions, type ProductOption } from './product-options';
+
+const defaultSnapshot = {
+  ingredientesCostoTotal: null,
+  costoTotalBatch: null,
+  costoUnitario: null,
+  precioSugerido: null,
+  margenRealPct: null,
+  lastCalculatedAt: null,
+};
+
+type FormState = {
+  nombre: string;
+  productId: number | null;
+  batchSize: number;
+  mermaPct: number | null;
+  costoManoObra: number | null;
+  costoEmpaque: number | null;
+  overheadPct: number | null;
+  margenObjetivoPct: number | null;
+  lineas: FabricacionDoc['lineas'];
+};
+
+type FormErrors = {
+  nombre?: string;
+  batchSize?: string;
+  lineas?: string[];
+};
+
+type Props = {
+  open: boolean;
+  mode: 'create' | 'edit';
+  initialData: FabricacionDoc | null;
+  loading: boolean;
+  saving: boolean;
+  recalculating?: boolean;
+  onClose: () => void;
+  onSubmit: (payload: FabricacionPayload) => Promise<void>;
+  onRecalculate?: () => void;
+};
+
+const loadProductOptions = (inputValue: string) => fetchProductOptions(inputValue, 20);
+
+function buildInitialState(data: FabricacionDoc | null): FormState {
+  if (!data) {
+    return {
+      nombre: '',
+      productId: null,
+      batchSize: 1,
+      mermaPct: null,
+      costoManoObra: null,
+      costoEmpaque: null,
+      overheadPct: null,
+      margenObjetivoPct: null,
+      lineas: [],
+    };
+  }
+  return {
+    nombre: data.nombre,
+    productId: data.product?.id ?? null,
+    batchSize: data.batchSize ?? 1,
+    mermaPct: data.mermaPct ?? null,
+    costoManoObra: data.costoManoObra ?? null,
+    costoEmpaque: data.costoEmpaque ?? null,
+    overheadPct: data.overheadPct ?? null,
+    margenObjetivoPct: data.margenObjetivoPct ?? null,
+    lineas: data.lineas.map((linea) => ({ ...linea })),
+  };
+}
+
+export default function FabricacionForm({
+  open,
+  mode,
+  initialData,
+  loading,
+  saving,
+  recalculating,
+  onClose,
+  onSubmit,
+  onRecalculate,
+}: Props) {
+  const [form, setForm] = useState<FormState>(() => buildInitialState(initialData));
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [productOption, setProductOption] = useState<ProductOption | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setForm(buildInitialState(initialData));
+      setErrors({});
+      if (initialData?.product) {
+        setProductOption({
+          value: initialData.product.id,
+          label: initialData.product.productName,
+          product: initialData.product,
+        });
+      } else {
+        setProductOption(null);
+      }
+    }
+  }, [open, initialData]);
+
+  const handleLineChange = (lineas: FormState['lineas']) => {
+    setForm((prev) => ({ ...prev, lineas }));
+  };
+
+  const validate = (): boolean => {
+    const nextErrors: FormErrors = {};
+    if (!form.nombre.trim()) {
+      nextErrors.nombre = 'El nombre es obligatorio';
+    }
+    if (!Number.isFinite(form.batchSize) || form.batchSize < 1) {
+      nextErrors.batchSize = 'El batch debe ser mayor o igual a 1';
+    }
+    const lineErrors = form.lineas.map(() => '');
+    if (form.lineas.length === 0) {
+      lineErrors.push('Agregá al menos un ingrediente');
+    } else {
+      form.lineas.forEach((linea, index) => {
+        if (!linea.ingredient) {
+          lineErrors[index] = 'Seleccioná un ingrediente';
+          return;
+        }
+        if (!Number.isFinite(linea.cantidad) || linea.cantidad <= 0) {
+          lineErrors[index] = 'Ingresá una cantidad válida';
+          return;
+        }
+        if (!linea.unidad || !linea.unidad.trim()) {
+          lineErrors[index] = 'Definí una unidad';
+        }
+      });
+    }
+    if (lineErrors.some(Boolean)) {
+      nextErrors.lineas = lineErrors;
+    }
+    setErrors(nextErrors);
+    return Object.keys(nextErrors).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+    const payload: FabricacionPayload = {
+      nombre: form.nombre.trim(),
+      productId: form.productId ?? null,
+      batchSize: Number(form.batchSize) || 1,
+      mermaPct: form.mermaPct ?? undefined,
+      costoManoObra: form.costoManoObra ?? undefined,
+      costoEmpaque: form.costoEmpaque ?? undefined,
+      overheadPct: form.overheadPct ?? undefined,
+      margenObjetivoPct: form.margenObjetivoPct ?? undefined,
+      lineas: form.lineas.map((linea) => ({
+        id: linea.id,
+        ingredientId: linea.ingredient?.id ?? null,
+        cantidad: Math.max(0, linea.cantidad),
+        unidad: linea.unidad.trim(),
+        mermaPct: linea.mermaPct == null ? undefined : Math.max(0, linea.mermaPct),
+        nota: linea.nota?.trim() ? linea.nota.trim() : null,
+      })),
+    };
+    await onSubmit(payload);
+  };
+
+  const missingIngredientPrice = useMemo(
+    () => form.lineas.some((linea) => linea.ingredient && (!linea.ingredient.price || linea.ingredient.price <= 0)),
+    [form.lineas],
+  );
+
+  const snapshot = initialData?.snapshots ?? defaultSnapshot;
+
+  const debouncedProductChange = useDebouncedCallback((option: ProductOption | null) => {
+    setForm((prev) => ({ ...prev, productId: option?.value ?? null }));
+  }, 50);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(value) => (!value ? onClose() : undefined)}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/40" />
+        <Dialog.Content className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="max-h-[90vh] w-full max-w-5xl overflow-y-auto rounded-3xl bg-white p-6 shadow-xl">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <Dialog.Title className="text-xl font-semibold text-[#5A3E1B]">
+                  {mode === 'edit' ? 'Editar fabricación' : 'Nueva fabricación'}
+                </Dialog.Title>
+                <Dialog.Description className="text-sm text-[#8c6d4c]">
+                  Completa los datos y guardá para mantener tus costos actualizados.
+                </Dialog.Description>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-full p-2 text-[#8c6d4c] transition hover:bg-[#f5e2ce]"
+                aria-label="Cerrar"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            {loading ? (
+              <div className="mt-6 space-y-4">
+                <div className="h-10 w-full animate-pulse rounded-xl bg-amber-100" />
+                <div className="h-40 w-full animate-pulse rounded-xl bg-amber-100" />
+              </div>
+            ) : (
+              <div className="mt-6 grid gap-6 lg:grid-cols-[2fr,1fr]">
+                <div className="space-y-6">
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Nombre *</label>
+                      <input
+                        type="text"
+                        value={form.nombre}
+                        onChange={(event) => setForm((prev) => ({ ...prev, nombre: event.target.value }))}
+                        className={`w-full rounded-lg border px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200 ${
+                          errors.nombre ? 'border-red-400 bg-red-50' : 'border-[#e6cdb0] bg-white'
+                        }`}
+                        placeholder="Ej. Salsa fileto 5kg"
+                      />
+                      {errors.nombre && <p className="text-xs text-red-600">{errors.nombre}</p>}
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Producto</label>
+                      <AsyncSelect
+                        cacheOptions
+                        loadOptions={loadProductOptions}
+                        defaultOptions
+                        value={productOption}
+                        onChange={(option) => {
+                          const next = option ? (option as ProductOption) : null;
+                          setProductOption(next);
+                          debouncedProductChange(next);
+                        }}
+                        isClearable
+                        placeholder="Buscar producto..."
+                        classNamePrefix="fabricacion-form-select"
+                        styles={{
+                          control: (base) => ({
+                            ...base,
+                            backgroundColor: '#fff7ee',
+                            borderColor: '#e6cdb0',
+                            borderRadius: 12,
+                            minHeight: 42,
+                          }),
+                          menu: (base) => ({ ...base, zIndex: 50 }),
+                        }}
+                        noOptionsMessage={() => 'Sin resultados'}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Batch size *</label>
+                      <input
+                        type="number"
+                        min={1}
+                        step="0.01"
+                        value={form.batchSize}
+                        onChange={(event) => {
+                          const valueNumber = Number(event.target.value);
+                          setForm((prev) => ({ ...prev, batchSize: Number.isFinite(valueNumber) ? valueNumber : prev.batchSize }));
+                        }}
+                        className={`w-full rounded-lg border px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200 ${
+                          errors.batchSize ? 'border-red-400 bg-red-50' : 'border-[#e6cdb0] bg-white'
+                        }`}
+                      />
+                      {errors.batchSize && <p className="text-xs text-red-600">{errors.batchSize}</p>}
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Merma %</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.1"
+                        value={form.mermaPct ?? ''}
+                        onChange={(event) => {
+                          const valueNumber = event.target.value === '' ? null : Number(event.target.value);
+                          setForm((prev) => ({
+                            ...prev,
+                            mermaPct: valueNumber === null || !Number.isFinite(valueNumber) ? null : Math.max(0, valueNumber),
+                          }));
+                        }}
+                        className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                        placeholder="0"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Costo mano de obra</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={form.costoManoObra ?? ''}
+                        onChange={(event) => {
+                          const valueNumber = event.target.value === '' ? null : Number(event.target.value);
+                          setForm((prev) => ({
+                            ...prev,
+                            costoManoObra:
+                              valueNumber === null || !Number.isFinite(valueNumber) ? null : Math.max(0, valueNumber),
+                          }));
+                        }}
+                        className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Costo empaque</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={form.costoEmpaque ?? ''}
+                        onChange={(event) => {
+                          const valueNumber = event.target.value === '' ? null : Number(event.target.value);
+                          setForm((prev) => ({
+                            ...prev,
+                            costoEmpaque:
+                              valueNumber === null || !Number.isFinite(valueNumber) ? null : Math.max(0, valueNumber),
+                          }));
+                        }}
+                        className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Overhead %</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.1"
+                        value={form.overheadPct ?? ''}
+                        onChange={(event) => {
+                          const valueNumber = event.target.value === '' ? null : Number(event.target.value);
+                          setForm((prev) => ({
+                            ...prev,
+                            overheadPct:
+                              valueNumber === null || !Number.isFinite(valueNumber) ? null : Math.max(0, valueNumber),
+                          }));
+                        }}
+                        className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-semibold text-[#5A3E1B]">Margen objetivo %</label>
+                      <input
+                        type="number"
+                        min={0}
+                        step="0.1"
+                        value={form.margenObjetivoPct ?? ''}
+                        onChange={(event) => {
+                          const valueNumber = event.target.value === '' ? null : Number(event.target.value);
+                          setForm((prev) => ({
+                            ...prev,
+                            margenObjetivoPct:
+                              valueNumber === null || !Number.isFinite(valueNumber) ? null : Math.max(0, valueNumber),
+                          }));
+                        }}
+                        className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                      />
+                    </div>
+                  </div>
+
+                  <LineaEditor value={form.lineas} onChange={handleLineChange} errors={errors.lineas} />
+                  {errors.lineas && form.lineas.length === 0 && (
+                    <p className="text-sm text-red-600">Agregá al menos un ingrediente antes de guardar.</p>
+                  )}
+                </div>
+
+                <div className="space-y-4">
+                  <ComputedSnapshot snapshot={snapshot} productPrice={initialData?.product?.price ?? null} />
+                  {missingIngredientPrice && (
+                    <div className="rounded-2xl border border-amber-300 bg-amber-50 p-3 text-sm text-[#5A3E1B]">
+                      Algunos ingredientes no tienen un precio vigente. El costo puede estar subestimado.
+                    </div>
+                  )}
+                  {onRecalculate && mode === 'edit' && (
+                    <RecalculateButton onClick={onRecalculate} loading={recalculating} />
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div className="mt-6 flex flex-col gap-3 border-t border-[#f0dcc3] pt-4 sm:flex-row sm:justify-end">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-xl border border-[#e6cdb0] px-4 py-2 text-sm font-semibold text-[#5A3E1B] transition hover:bg-[#fff7ee]"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={saving}
+                className="rounded-xl bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving ? 'Guardando…' : 'Guardar'}
+              </button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/components/sections/admin/fabricacion/FabricacionSection.tsx
+++ b/components/sections/admin/fabricacion/FabricacionSection.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useMemo } from 'react';
+import { toast } from 'sonner';
+import FabricacionFilters from './FabricacionFilters';
+import FabricacionTable from './FabricacionTable';
+import FabricacionForm from './FabricacionForm';
+import { useFabricacionAdminStore } from './hooks/useFabricacionAdmin';
+
+export default function FabricacionSection() {
+  const {
+    filters,
+    meta,
+    items,
+    loading,
+    showForm,
+    formMode,
+    current,
+    formLoading,
+    saving,
+    deletingId,
+    recalculatingId,
+    fetchList,
+    setFilters,
+    openCreate,
+    openEdit,
+    closeForm,
+    saveFabricacion,
+    removeFabricacion,
+    triggerRecalculate,
+  } = useFabricacionAdminStore();
+
+  useEffect(() => {
+    fetchList().catch((error) => {
+      console.error('[fabricacion-ui] initial fetch error', error);
+      toast.error('No se pudieron cargar las fabricaciones');
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const headerSubtitle = useMemo(() => {
+    const total = meta.total ?? items.length;
+    return total === 1 ? '1 fabricación registrada' : `${total} fabricaciones registradas`;
+  }, [items.length, meta.total]);
+
+  const handleSearch = (search: string) => {
+    setFilters({ search });
+    fetchList({ search }).catch((error) => {
+      console.error('[fabricacion-ui] search error', error);
+      toast.error('No se pudo aplicar el filtro');
+    });
+  };
+
+  const handleStatusChange = (status: 'all' | 'draft' | 'published') => {
+    setFilters({ status });
+    fetchList({ status }).catch((error) => {
+      console.error('[fabricacion-ui] status error', error);
+      toast.error('No se pudo aplicar el filtro');
+    });
+  };
+
+  const handleProductChange = (productId: number | null) => {
+    setFilters({ productId });
+    fetchList({ productId: productId ?? null }).catch((error) => {
+      console.error('[fabricacion-ui] product filter error', error);
+      toast.error('No se pudo aplicar el filtro');
+    });
+  };
+
+  const handlePageChange = (page: number) => {
+    setFilters({ page });
+    fetchList({ page }).catch((error) => {
+      console.error('[fabricacion-ui] pagination error', error);
+      toast.error('No se pudieron cargar los resultados');
+    });
+  };
+
+  const handleDelete = async (id: number) => {
+    const confirmed = window.confirm('¿Seguro que deseas eliminar esta fabricación?');
+    if (!confirmed) return;
+    try {
+      await removeFabricacion(id);
+    } catch (error) {
+      console.error('[fabricacion-ui] delete error', error);
+      toast.error('No se pudo eliminar la fabricación');
+    }
+  };
+
+  const handleSave = async (payload: Parameters<typeof saveFabricacion>[0]) => {
+    try {
+      await saveFabricacion(payload);
+    } catch (error) {
+      console.error('[fabricacion-ui] save error', error);
+      const message = error instanceof Error ? error.message : 'Error guardando la fabricación';
+      toast.error(message);
+      throw error;
+    }
+  };
+
+  const handleRecalculate = async (id: number) => {
+    try {
+      await triggerRecalculate(id);
+    } catch (error) {
+      console.error('[fabricacion-ui] recalc error', error);
+      const message = error instanceof Error ? error.message : 'Error recalculando costos';
+      toast.error(message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-[#5A3E1B]">Fórmulas de fabricación</h1>
+          <p className="text-sm text-[#8c6d4c]">{headerSubtitle}</p>
+        </div>
+        <button
+          type="button"
+          onClick={openCreate}
+          className="inline-flex items-center justify-center rounded-xl bg-amber-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-amber-700"
+        >
+          Nueva fabricación
+        </button>
+      </div>
+
+      <div className="rounded-2xl bg-[#fef6ef] p-4 shadow-sm">
+        <FabricacionFilters
+          filters={filters}
+          onSearchChange={handleSearch}
+          onStatusChange={handleStatusChange}
+          onProductChange={handleProductChange}
+          onReset={() => {
+            setFilters({ search: '', status: 'all', productId: null, page: 1 });
+            fetchList({ search: '', status: 'all', productId: null, page: 1 }).catch((error) => {
+              console.error('[fabricacion-ui] reset filters error', error);
+              toast.error('No se pudieron restablecer los filtros');
+            });
+          }}
+        />
+      </div>
+
+      <div className="rounded-2xl bg-white p-4 shadow">
+        <FabricacionTable
+          items={items}
+          loading={loading}
+          meta={meta}
+          onEdit={(id) => openEdit(id).catch(() => {})}
+          onDelete={handleDelete}
+          onRecalculate={handleRecalculate}
+          onPageChange={handlePageChange}
+          deletingId={deletingId}
+          recalculatingId={recalculatingId}
+        />
+      </div>
+
+      <FabricacionForm
+        open={showForm}
+        mode={formMode}
+        initialData={current}
+        loading={formLoading}
+        saving={saving}
+        onClose={closeForm}
+        onSubmit={handleSave}
+        onRecalculate={current ? () => handleRecalculate(current.id) : undefined}
+        recalculating={current ? recalculatingId === current.id : false}
+      />
+    </div>
+  );
+}

--- a/components/sections/admin/fabricacion/FabricacionTable.tsx
+++ b/components/sections/admin/fabricacion/FabricacionTable.tsx
@@ -1,0 +1,167 @@
+"use client";
+import { FabricacionDoc, FabricacionListMeta } from '@/types/fabricacion';
+import RecalculateButton from './RecalculateButton';
+
+type Props = {
+  items: FabricacionDoc[];
+  loading: boolean;
+  meta: FabricacionListMeta;
+  onEdit: (id: number) => void;
+  onDelete: (id: number) => void;
+  onRecalculate: (id: number) => void;
+  onPageChange: (page: number) => void;
+  deletingId: number | null;
+  recalculatingId: number | null;
+};
+
+const numberFormatter = new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const currencyFormatter = new Intl.NumberFormat('es-AR', {
+  style: 'currency',
+  currency: 'ARS',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+const dateFormatter = new Intl.DateTimeFormat('es-AR', { dateStyle: 'short', timeStyle: 'short' });
+
+function formatCurrency(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—';
+  return currencyFormatter.format(value);
+}
+
+function formatPercent(value: number | null | undefined) {
+  if (value === null || value === undefined) return '—';
+  return `${numberFormatter.format(value)}%`;
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return '—';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return dateFormatter.format(parsed);
+}
+
+export default function FabricacionTable({
+  items,
+  loading,
+  meta,
+  onEdit,
+  onDelete,
+  onRecalculate,
+  onPageChange,
+  deletingId,
+  recalculatingId,
+}: Props) {
+  const totalPages = Math.max(1, meta.pageCount || Math.ceil((meta.total || items.length || 1) / (meta.pageSize || 10)));
+  const currentPage = Math.min(meta.page || 1, totalPages);
+
+  return (
+    <div className="space-y-4">
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-[#f0dcc3]">
+          <thead className="bg-[#fef1e4]">
+            <tr>
+              {['Nombre', 'Producto', 'Batch', 'Líneas', 'Costo unitario', 'Margen real', 'Actualizado', 'Acciones'].map((header) => (
+                <th key={header} className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-[#5A3E1B]">
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[#f0dcc3] bg-white">
+            {loading ? (
+              <tr>
+                <td colSpan={8} className="px-4 py-6">
+                  <div className="h-8 w-full animate-pulse rounded-lg bg-amber-100" />
+                </td>
+              </tr>
+            ) : items.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="px-4 py-8 text-center text-sm text-[#8c6d4c]">
+                  No hay fabricaciones registradas todavía.
+                </td>
+              </tr>
+            ) : (
+              items.map((item) => {
+                const lineCount = item.lineas.length;
+                const costoUnitario = item.snapshots?.costoUnitario ?? null;
+                const margenReal = item.product?.price ? item.snapshots?.margenRealPct : null;
+                const lastCalculated = item.snapshots?.lastCalculatedAt;
+                const stale = item.needsRecalculation || !lastCalculated;
+                return (
+                  <tr key={item.id} className="hover:bg-[#fff7ee]">
+                    <td className="px-4 py-3">
+                      <div className="flex flex-col">
+                        <span className="font-medium text-[#5A3E1B]">{item.nombre}</span>
+                        {stale && (
+                          <span className="mt-1 inline-flex w-fit rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                            Desactualizado
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[#5A3E1B]">
+                      {item.product ? item.product.productName : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-[#5A3E1B]">{numberFormatter.format(item.batchSize)}</td>
+                    <td className="px-4 py-3 text-sm text-[#5A3E1B]">{lineCount}</td>
+                    <td className="px-4 py-3 text-sm text-[#5A3E1B]">{formatCurrency(costoUnitario)}</td>
+                    <td className="px-4 py-3 text-sm text-[#5A3E1B]">{margenReal !== null ? formatPercent(margenReal) : '—'}</td>
+                    <td className="px-4 py-3 text-sm text-[#5A3E1B]">{formatDate(lastCalculated)}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onEdit(item.id)}
+                          className="rounded-lg border border-amber-500 px-3 py-1 text-xs font-semibold text-amber-700 transition hover:bg-amber-50"
+                        >
+                          Editar
+                        </button>
+                        <RecalculateButton
+                          onClick={() => onRecalculate(item.id)}
+                          loading={recalculatingId === item.id}
+                          size="sm"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => onDelete(item.id)}
+                          disabled={deletingId === item.id}
+                          className="rounded-lg border border-red-400 px-3 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {deletingId === item.id ? 'Eliminando…' : 'Eliminar'}
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-[#5A3E1B]">
+        <span>
+          Página {currentPage} de {totalPages}
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+            disabled={currentPage <= 1 || loading}
+            className="rounded-lg border border-[#e6cdb0] px-3 py-1 text-xs font-semibold text-[#5A3E1B] transition hover:bg-[#fff7ee] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+            disabled={currentPage >= totalPages || loading}
+            className="rounded-lg border border-[#e6cdb0] px-3 py-1 text-xs font-semibold text-[#5A3E1B] transition hover:bg-[#fff7ee] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Siguiente
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sections/admin/fabricacion/LineaEditor.tsx
+++ b/components/sections/admin/fabricacion/LineaEditor.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useMemo, useState } from 'react';
+import { useDebouncedCallback } from 'use-debounce';
+import type { FabricacionLine, IngredienteLite } from '@/types/fabricacion';
+import type { IngredientType } from '@/types/ingredient';
+
+const unidadHelper = 'Ej. "kg", "g", "l", "ml", "unidad", "bolsa 25kg"';
+
+type Props = {
+  value: FabricacionLine[];
+  onChange: (lines: FabricacionLine[]) => void;
+  errors?: string[];
+};
+
+type IngredientOption = {
+  value: number;
+  label: string;
+  ingredient: IngredienteLite;
+};
+
+export default function LineaEditor({ value, onChange, errors }: Props) {
+  const addLine = () => {
+    onChange([
+      ...value,
+      {
+        id: undefined,
+        ingredient: null,
+        cantidad: 1,
+        unidad: '',
+        mermaPct: null,
+        nota: '',
+      },
+    ]);
+  };
+
+  const updateLine = (index: number, updater: (line: FabricacionLine) => FabricacionLine) => {
+    const next = value.map((linea, idx) => (idx === index ? updater(linea) : linea));
+    onChange(next);
+  };
+
+  const removeLine = (index: number) => {
+    const next = value.filter((_, idx) => idx !== index);
+    onChange(next);
+  };
+
+  const lineErrors = useMemo(() => errors ?? [], [errors]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-[#5A3E1B]">Líneas de ingredientes</h3>
+        <button
+          type="button"
+          onClick={addLine}
+          className="rounded-lg border border-amber-500 px-3 py-1 text-xs font-semibold text-amber-700 transition hover:bg-amber-50"
+        >
+          Agregar línea
+        </button>
+      </div>
+      {value.length === 0 && (
+        <p className="text-sm text-[#8c6d4c]">Agregá al menos un ingrediente con su cantidad.</p>
+      )}
+      <div className="space-y-6">
+        {value.map((linea, index) => (
+          <div key={index} className="rounded-2xl border border-[#f0dcc3] bg-[#fffaf4] p-4 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <span className="rounded-full bg-[#fef1e4] px-3 py-1 text-xs font-semibold uppercase text-[#b27742]">Línea {index + 1}</span>
+              <button
+                type="button"
+                onClick={() => removeLine(index)}
+                className="text-xs font-semibold text-red-600 hover:underline"
+              >
+                Quitar
+              </button>
+            </div>
+
+            <div className="mt-4 grid gap-4 md:grid-cols-2">
+              <div className="space-y-1">
+                <label className="text-sm font-semibold text-[#5A3E1B]">Ingrediente *</label>
+                <IngredientAutocomplete
+                  value={linea.ingredient}
+                  onSelect={(ingredient) => updateLine(index, (prev) => ({ ...prev, ingredient }))}
+                  error={lineErrors[index]}
+                />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-1">
+                  <label className="text-sm font-semibold text-[#5A3E1B]">Cantidad *</label>
+                  <input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={linea.cantidad}
+                    onChange={(event) => {
+                      const cantidad = Number(event.target.value);
+                      updateLine(index, (prev) => ({ ...prev, cantidad: Number.isFinite(cantidad) ? cantidad : prev.cantidad }));
+                    }}
+                    className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-sm font-semibold text-[#5A3E1B]">Unidad *</label>
+                  <input
+                    type="text"
+                    value={linea.unidad}
+                    onChange={(event) => {
+                      const unidad = event.target.value;
+                      updateLine(index, (prev) => ({ ...prev, unidad }));
+                    }}
+                    placeholder={unidadHelper}
+                    className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                  />
+                  <p className="text-xs text-[#a57c52]">{unidadHelper}</p>
+                </div>
+              </div>
+              <div className="space-y-1">
+                <label className="text-sm font-semibold text-[#5A3E1B]">Merma %</label>
+                <input
+                  type="number"
+                  min={0}
+                  step="0.1"
+                  value={linea.mermaPct ?? ''}
+                  onChange={(event) => {
+                    const valueNumber = event.target.value === '' ? null : Number(event.target.value);
+                    updateLine(index, (prev) => ({ ...prev, mermaPct: valueNumber === null || Number.isFinite(valueNumber) ? valueNumber : prev.mermaPct }));
+                  }}
+                  className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                  placeholder="0"
+                />
+              </div>
+              <div className="space-y-1 md:col-span-2">
+                <label className="text-sm font-semibold text-[#5A3E1B]">Nota</label>
+                <textarea
+                  value={linea.nota ?? ''}
+                  onChange={(event) => {
+                    const nota = event.target.value;
+                    updateLine(index, (prev) => ({ ...prev, nota }));
+                  }}
+                  rows={2}
+                  className="w-full rounded-lg border border-[#e6cdb0] bg-white px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200"
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+type AutocompleteProps = {
+  value: IngredienteLite | null;
+  onSelect: (ingredient: IngredienteLite | null) => void;
+  error?: string;
+};
+
+function IngredientAutocomplete({ value, onSelect, error }: AutocompleteProps) {
+  const [inputValue, setInputValue] = useState<string>(value?.ingredienteName ?? '');
+  const [options, setOptions] = useState<IngredientOption[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setInputValue(value?.ingredienteName ?? '');
+  }, [value?.id, value?.ingredienteName]);
+
+  const fetchOptions = useDebouncedCallback(async (query: string) => {
+    const params = new URLSearchParams();
+    if (query) params.set('q', query);
+    params.set('pageSize', '10');
+    try {
+      const res = await fetch(`/api/admin/ingredients?${params.toString()}`, { cache: 'no-store' });
+      if (!res.ok) {
+        setOptions([]);
+        return;
+      }
+      const json = await res.json();
+      const items = Array.isArray(json?.items) ? (json.items as IngredientType[]) : [];
+      const mapped = items.map((item) => ({
+        value: item.id,
+        label: item.ingredienteName,
+        ingredient: {
+          id: item.id,
+          documentId: item.documentId,
+          ingredienteName: item.ingredienteName,
+          unidadMedida: item.unidadMedida,
+          price: item.precio,
+        } satisfies IngredienteLite,
+      }));
+      setOptions(mapped);
+    } catch (err) {
+      console.error('[fabricacion-ui] ingredient search error', err);
+      setOptions([]);
+    }
+  }, 300);
+
+  return (
+    <div className="relative">
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(event) => {
+          const next = event.target.value;
+          setInputValue(next);
+          setOpen(true);
+          fetchOptions(next);
+        }}
+        onFocus={() => {
+          setOpen(true);
+          fetchOptions(inputValue);
+        }}
+        onBlur={() => {
+          setTimeout(() => setOpen(false), 150);
+        }}
+        placeholder="Buscar ingrediente..."
+        className={`w-full rounded-lg border px-3 py-2 text-sm text-[#5A3E1B] focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-200 ${
+          error ? 'border-red-400 bg-red-50' : 'border-[#e6cdb0] bg-white'
+        }`}
+      />
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+      {open && options.length > 0 && (
+        <ul className="absolute z-20 mt-1 max-h-48 w-full overflow-auto rounded-lg border border-[#f0dcc3] bg-white shadow-lg">
+          {options.map((option) => (
+            <li
+              key={option.value}
+              className="cursor-pointer px-3 py-2 text-sm text-[#5A3E1B] hover:bg-[#fff7ee]"
+              onMouseDown={(event) => {
+                event.preventDefault();
+                setInputValue(option.label);
+                onSelect(option.ingredient);
+                setOpen(false);
+              }}
+            >
+              <div className="flex flex-col">
+                <span className="font-medium">{option.label}</span>
+                <span className="text-xs text-[#a57c52]">
+                  {option.ingredient.unidadMedida ? `Unidad: ${option.ingredient.unidadMedida}` : 'Sin unidad definida'} ·{' '}
+                  {option.ingredient.price != null ? `Precio: ${option.ingredient.price}` : 'Sin precio activo'}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/sections/admin/fabricacion/RecalculateButton.tsx
+++ b/components/sections/admin/fabricacion/RecalculateButton.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Loader2, RefreshCw } from 'lucide-react';
+import { ButtonHTMLAttributes } from 'react';
+
+type Props = {
+  onClick: () => void;
+  loading?: boolean;
+  size?: 'sm' | 'md';
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick'>;
+
+export default function RecalculateButton({ onClick, loading, size = 'md', ...rest }: Props) {
+  const baseClasses =
+    'inline-flex items-center gap-1 rounded-lg bg-emerald-600 text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60';
+  const sizeClasses = size === 'sm' ? 'px-3 py-1 text-xs font-semibold' : 'px-4 py-2 text-sm font-semibold';
+
+  return (
+    <button type="button" onClick={onClick} disabled={loading} className={`${baseClasses} ${sizeClasses}`} {...rest}>
+      {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+      <span>{loading ? 'Recalculando…' : 'Recalcular'}</span>
+    </button>
+  );
+}

--- a/components/sections/admin/fabricacion/hooks/useFabricacionAdmin.ts
+++ b/components/sections/admin/fabricacion/hooks/useFabricacionAdmin.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { create } from 'zustand';
+import { toast } from 'sonner';
+import {
+  createFabricacion,
+  deleteFabricacion,
+  getFabricacion,
+  listFabricaciones,
+  recalculateFabricacion,
+  updateFabricacion,
+} from '@/lib/admin/fabricacion-api';
+import {
+  FabricacionDoc,
+  FabricacionFiltersState,
+  FabricacionListMeta,
+  FabricacionPayload,
+} from '@/types/fabricacion';
+
+type FormMode = 'create' | 'edit';
+
+type State = {
+  filters: FabricacionFiltersState;
+  meta: FabricacionListMeta;
+  items: FabricacionDoc[];
+  loading: boolean;
+  error: string | null;
+  showForm: boolean;
+  formMode: FormMode;
+  current: FabricacionDoc | null;
+  formLoading: boolean;
+  saving: boolean;
+  deletingId: number | null;
+  recalculatingId: number | null;
+};
+
+type Actions = {
+  fetchList: (override?: Partial<FabricacionFiltersState>) => Promise<void>;
+  setFilters: (update: Partial<FabricacionFiltersState>) => void;
+  openCreate: () => void;
+  openEdit: (id: number) => Promise<void>;
+  closeForm: () => void;
+  saveFabricacion: (payload: FabricacionPayload) => Promise<FabricacionDoc>;
+  removeFabricacion: (id: number) => Promise<void>;
+  triggerRecalculate: (id: number) => Promise<FabricacionDoc>;
+};
+
+const defaultMeta: FabricacionListMeta = { page: 1, pageSize: 10, total: 0, pageCount: 1 };
+
+export const useFabricacionAdminStore = create<State & Actions>((set, get) => ({
+  filters: { search: '', status: 'all', productId: null, page: 1, pageSize: 10 },
+  meta: defaultMeta,
+  items: [],
+  loading: false,
+  error: null,
+  showForm: false,
+  formMode: 'create',
+  current: null,
+  formLoading: false,
+  saving: false,
+  deletingId: null,
+  recalculatingId: null,
+
+  async fetchList(override) {
+    const currentFilters = get().filters;
+    const nextFilters = { ...currentFilters, ...(override || {}) } as FabricacionFiltersState;
+    if (override && ('search' in override || 'status' in override || 'productId' in override)) {
+      nextFilters.page = 1;
+    }
+    set({ loading: true, filters: nextFilters, error: null });
+    try {
+      console.log('[fabricacion-store] fetchList', nextFilters);
+      const res = await listFabricaciones(nextFilters);
+      const items = Array.isArray(res.items) ? res.items : [];
+      const meta = res.meta ?? defaultMeta;
+      set({ items, meta, loading: false });
+    } catch (error) {
+      console.error('[fabricacion-store] fetchList error', error);
+      set({ items: [], meta: defaultMeta, loading: false, error: 'Error cargando fabricaciones' });
+      throw error;
+    }
+  },
+
+  setFilters(update) {
+    const next = { ...get().filters, ...(update || {}) } as FabricacionFiltersState;
+    set({ filters: next });
+  },
+
+  openCreate() {
+    set({ showForm: true, formMode: 'create', current: null, formLoading: false });
+  },
+
+  async openEdit(id) {
+    set({ showForm: true, formMode: 'edit', formLoading: true, current: null });
+    try {
+      console.log('[fabricacion-store] openEdit', id);
+      const res = await getFabricacion(id);
+      set({ current: res.item, formLoading: false });
+    } catch (error) {
+      console.error('[fabricacion-store] openEdit error', error);
+      set({ formLoading: false });
+      toast.error('No se pudo cargar la fabricación');
+      throw error;
+    }
+  },
+
+  closeForm() {
+    set({ showForm: false, formMode: 'create', current: null });
+  },
+
+  async saveFabricacion(payload) {
+    const mode = get().formMode;
+    const current = get().current;
+    set({ saving: true });
+    try {
+      let item: FabricacionDoc;
+      if (mode === 'edit' && current) {
+        item = await updateFabricacion(current.id, payload);
+        toast.success('Fabricación actualizada');
+      } else {
+        item = await createFabricacion(payload);
+        toast.success('Fabricación creada');
+      }
+      const items = get().items;
+      const updatedItems = mode === 'edit' && current
+        ? items.map((it) => (it.id === current.id ? item : it))
+        : [item, ...items];
+      set({ items: updatedItems, current: item, saving: false, formMode: 'edit' });
+      void get().fetchList();
+      return item;
+    } catch (error) {
+      console.error('[fabricacion-store] saveFabricacion error', error);
+      set({ saving: false });
+      throw error;
+    }
+  },
+
+  async removeFabricacion(id) {
+    set({ deletingId: id });
+    try {
+      await deleteFabricacion(id);
+      toast.success('Fabricación eliminada');
+      const items = get().items.filter((item) => item.id !== id);
+      set({ items, deletingId: null });
+      void get().fetchList();
+    } catch (error) {
+      console.error('[fabricacion-store] removeFabricacion error', error);
+      set({ deletingId: null });
+      throw error;
+    }
+  },
+
+  async triggerRecalculate(id) {
+    set({ recalculatingId: id });
+    try {
+      const item = await recalculateFabricacion(id);
+      toast.success('Costos recalculados');
+      const items = get().items.map((fabricacion) => (fabricacion.id === id ? item : fabricacion));
+      const isEditing = get().current?.id === id;
+      set({ items, recalculatingId: null, current: isEditing ? item : get().current });
+      return item;
+    } catch (error) {
+      console.error('[fabricacion-store] triggerRecalculate error', error);
+      set({ recalculatingId: null });
+      throw error;
+    }
+  },
+}));

--- a/components/sections/admin/fabricacion/product-options.ts
+++ b/components/sections/admin/fabricacion/product-options.ts
@@ -1,0 +1,25 @@
+import type { ProductLite } from '@/types/fabricacion';
+
+type ProductOption = {
+  value: number;
+  label: string;
+  product: ProductLite;
+};
+
+export async function fetchProductOptions(query: string, pageSize = 20): Promise<ProductOption[]> {
+  const params = new URLSearchParams();
+  if (query) params.set('q', query);
+  params.set('pageSize', String(pageSize));
+  try {
+    const res = await fetch(`/api/admin/fabricacions/products?${params.toString()}`, { cache: 'no-store' });
+    if (!res.ok) return [];
+    const json = await res.json();
+    const items = Array.isArray(json?.items) ? (json.items as ProductLite[]) : [];
+    return items.map((product) => ({ value: product.id, label: product.productName, product }));
+  } catch (error) {
+    console.error('[fabricacion-ui] fetchProductOptions error', error);
+    return [];
+  }
+}
+
+export type { ProductOption };

--- a/lib/admin/fabricacion-api.ts
+++ b/lib/admin/fabricacion-api.ts
@@ -1,0 +1,107 @@
+import {
+  FabricacionDoc,
+  FabricacionFiltersState,
+  FabricacionListMeta,
+  FabricacionPayload,
+} from '@/types/fabricacion';
+
+export type ListFabricacionesResponse = {
+  ok: boolean;
+  items: FabricacionDoc[];
+  meta: FabricacionListMeta;
+};
+
+export type GetFabricacionResponse = {
+  ok: boolean;
+  item: FabricacionDoc;
+};
+
+function toQuery(params: Partial<FabricacionFiltersState>): string {
+  const searchParams = new URLSearchParams();
+  if (params.search) searchParams.set('search', params.search.trim());
+  if (params.productId) searchParams.set('productId', String(params.productId));
+  if (params.status && params.status !== 'all') searchParams.set('status', params.status);
+  if (params.page) searchParams.set('page', String(params.page));
+  if (params.pageSize) searchParams.set('pageSize', String(params.pageSize));
+  return searchParams.toString();
+}
+
+export async function listFabricaciones(params: Partial<FabricacionFiltersState> = {}): Promise<ListFabricacionesResponse> {
+  const query = toQuery(params);
+  const url = `/api/admin/fabricacions${query ? `?${query}` : ''}`;
+  console.log('[fabricacion-api] listFabricaciones', url);
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[fabricacion-api] listFabricaciones error', res.status, text);
+    throw new Error('Error listando fabricaciones');
+  }
+  const json = (await res.json()) as ListFabricacionesResponse;
+  return json;
+}
+
+export async function getFabricacion(id: number | string): Promise<GetFabricacionResponse> {
+  const res = await fetch(`/api/admin/fabricacions/${id}`, { cache: 'no-store' });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[fabricacion-api] getFabricacion error', res.status, text);
+    throw new Error('Error obteniendo fabricación');
+  }
+  const json = (await res.json()) as GetFabricacionResponse;
+  return json;
+}
+
+export async function createFabricacion(payload: FabricacionPayload): Promise<FabricacionDoc> {
+  console.log('[fabricacion-api] createFabricacion payload', payload);
+  const res = await fetch('/api/admin/fabricacions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[fabricacion-api] createFabricacion error', res.status, text);
+    throw new Error(text || 'Error creando fabricación');
+  }
+  const json = (await res.json()) as GetFabricacionResponse;
+  return json.item;
+}
+
+export async function updateFabricacion(id: number | string, payload: FabricacionPayload): Promise<FabricacionDoc> {
+  console.log('[fabricacion-api] updateFabricacion payload', { id, payload });
+  const res = await fetch(`/api/admin/fabricacions/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[fabricacion-api] updateFabricacion error', res.status, text);
+    throw new Error(text || 'Error actualizando fabricación');
+  }
+  const json = (await res.json()) as GetFabricacionResponse;
+  return json.item;
+}
+
+export async function deleteFabricacion(id: number | string): Promise<{ ok: true }>{
+  console.log('[fabricacion-api] deleteFabricacion', { id });
+  const res = await fetch(`/api/admin/fabricacions/${id}`, { method: 'DELETE' });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[fabricacion-api] deleteFabricacion error', res.status, text);
+    throw new Error(text || 'Error eliminando fabricación');
+  }
+  return { ok: true };
+}
+
+export async function recalculateFabricacion(id: number | string): Promise<FabricacionDoc> {
+  console.log('[fabricacion-api] recalculateFabricacion', { id });
+  const res = await fetch(`/api/admin/fabricacions/${id}/recalculate`, { method: 'POST' });
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('[fabricacion-api] recalculateFabricacion error', res.status, text);
+    throw new Error(text || 'Error recalculando costos');
+  }
+  const json = (await res.json()) as GetFabricacionResponse;
+  return json.item;
+}

--- a/types/fabricacion.ts
+++ b/types/fabricacion.ts
@@ -1,0 +1,93 @@
+export type ProductLite = {
+  id: number;
+  documentId?: string | null;
+  productName: string;
+  slug?: string | null;
+  price?: number | null;
+};
+
+export type IngredienteLite = {
+  id: number;
+  documentId?: string | null;
+  ingredienteName: string;
+  unidadMedida?: string | null;
+  price?: number | null;
+};
+
+export type FabricacionLine = {
+  id?: number;
+  ingredient: IngredienteLite | null;
+  cantidad: number;
+  unidad: string;
+  mermaPct?: number | null;
+  nota?: string | null;
+};
+
+export type FabricacionSnapshot = {
+  ingredientesCostoTotal: number | null;
+  costoTotalBatch: number | null;
+  costoUnitario: number | null;
+  precioSugerido: number | null;
+  margenRealPct: number | null;
+  lastCalculatedAt: string | null;
+};
+
+export type FabricacionDoc = {
+  id: number;
+  documentId?: string | null;
+  nombre: string;
+  product: ProductLite | null;
+  batchSize: number;
+  mermaPct: number | null;
+  costoManoObra: number | null;
+  costoEmpaque: number | null;
+  overheadPct: number | null;
+  margenObjetivoPct: number | null;
+  lineas: FabricacionLine[];
+  snapshots: FabricacionSnapshot;
+  updatedAt?: string | null;
+  publishedAt?: string | null;
+  createdAt?: string | null;
+  needsRecalculation: boolean;
+};
+
+export type FabricacionListMeta = {
+  page: number;
+  pageSize: number;
+  pageCount: number;
+  total: number;
+};
+
+export type FabricacionListResponse = {
+  items: FabricacionDoc[];
+  meta: FabricacionListMeta;
+};
+
+export type FabricacionPayloadLine = {
+  id?: number;
+  ingredientId: number | null;
+  cantidad: number;
+  unidad: string;
+  mermaPct?: number | null;
+  nota?: string | null;
+};
+
+export type FabricacionPayload = {
+  nombre: string;
+  productId?: number | null;
+  batchSize: number;
+  mermaPct?: number | null;
+  costoManoObra?: number | null;
+  costoEmpaque?: number | null;
+  overheadPct?: number | null;
+  margenObjetivoPct?: number | null;
+  lineas: FabricacionPayloadLine[];
+};
+
+export type FabricacionFiltersState = {
+  search: string;
+  status: 'all' | 'draft' | 'published';
+  productId: number | null;
+  page: number;
+  pageSize: number;
+};


### PR DESCRIPTION
## Summary
- add `/admin/fabricacion` page with search, table, and form to manage manufacturing formulas
- create client store, editors, and computed snapshot components for BOM editing and recalculation
- expose Strapi-backed API routes and helpers plus shared types for fabricación records and lookups

## Testing
- `npm run lint` *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d600e448088321959910426b24e86e