### PR TITLE
Fix fabricacion populate queries and add detail endpoint

### DIFF
--- a/app/api/admin/fabricacion/[documentId]/route.ts
+++ b/app/api/admin/fabricacion/[documentId]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { strapiFetch } from "../../suppliers/strapi-helpers";
+import { Fabricacion } from "@/types/fabricacion";
+import { ensureFabricacionPopulate, mapFabricacion, normalizeFabricacionPopulate } from "../shared";
+
+export async function GET(req: NextRequest, ctx: { params: Promise<{ documentId: string }> }) {
+  try {
+    const { documentId } = await ctx.params;
+    const trimmed = documentId?.trim();
+    if (!trimmed) {
+      return NextResponse.json({ error: "Falta documentId" }, { status: 400 });
+    }
+
+    const url = new URL(req.url);
+    const params = new URLSearchParams(url.searchParams);
+    normalizeFabricacionPopulate(params);
+    ensureFabricacionPopulate(params);
+
+    const query = params.toString();
+    const path = `/api/fabricacions/${encodeURIComponent(trimmed)}${query ? `?${query}` : ""}`;
+    const res = await strapiFetch(path);
+    const text = await res.text();
+
+    if (!res.ok) {
+      console.error("[admin/fabricacion byId][GET] Strapi error", { status: res.status, body: text });
+      if (res.status === 404) {
+        return NextResponse.json({ error: "Fabricación no encontrada" }, { status: 404 });
+      }
+      if (res.status === 400) {
+        return NextResponse.json(
+          {
+            error:
+              "Strapi rechazó la consulta de fabricación (parámetros inválidos). Intenta recargar o avisa al equipo si persiste.",
+          },
+          { status: 502 }
+        );
+      }
+      return NextResponse.json({ error: "No se pudo obtener la información de fabricación" }, { status: 502 });
+    }
+
+    const json = text ? JSON.parse(text) : {};
+    const raw = json?.data ?? json;
+    const item = mapFabricacion(raw);
+    if (!item) {
+      return NextResponse.json({ error: "Fabricación no encontrada" }, { status: 404 });
+    }
+
+    return NextResponse.json(item as Fabricacion);
+  } catch (error) {
+    console.error("[admin/fabricacion byId][GET] Unexpected error", error);
+    return NextResponse.json(
+      { error: "Error inesperado obteniendo la orden de fabricación" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/fabricacion/route.ts
+++ b/app/api/admin/fabricacion/route.ts
@@ -1,132 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { strapiFetch } from "../suppliers/strapi-helpers";
-import { Fabricacion, FabricacionLine, FabricacionListResponse, FabricacionProduct } from "@/types/fabricacion";
-
-function toNumber(value: unknown, fallback = 0): number {
-  const source = typeof value === "string" ? value.trim() : value;
-  const num = Number(source);
-  return Number.isFinite(num) ? num : fallback;
-}
-
-function toNullableNumber(value: unknown): number | null {
-  const source = typeof value === "string" ? value.trim() : value;
-  if (source === "" || source === null || source === undefined) return null;
-  const num = Number(source);
-  return Number.isFinite(num) ? num : null;
-}
-
-function toOptionalNumber(value: unknown): number | undefined {
-  const num = toNullableNumber(value);
-  return num === null ? undefined : num;
-}
-
-function toStringOrNull(value: unknown): string | null {
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed === "" ? null : trimmed;
-  }
-  return value == null ? null : String(value);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function normalizeEntity<T extends Record<string, unknown>>(node: unknown): T | null {
-  if (!isRecord(node)) return null;
-  const record = node as Record<string, unknown>;
-  if (isRecord(record.data)) {
-    return normalizeEntity(record.data);
-  }
-  if (isRecord(record.attributes)) {
-    return { ...record, ...(record.attributes as Record<string, unknown>) } as T;
-  }
-  return record as T;
-}
-
-function normalizeArray(value: unknown): unknown[] {
-  if (Array.isArray(value)) return value;
-  if (isRecord(value) && Array.isArray(value.data)) return value.data as unknown[];
-  return [];
-}
-
-function mapProduct(node: unknown): FabricacionProduct | null {
-  const entry = normalizeEntity<Record<string, unknown>>(node);
-  if (!entry) return null;
-  const documentId = toStringOrNull(entry.documentId) ?? toStringOrNull(entry.document_id);
-  const productName =
-    toStringOrNull(entry.productName) ?? toStringOrNull(entry.name) ?? toStringOrNull(entry.titulo) ?? "";
-  if (!documentId || !productName) return null;
-  return {
-    id: toOptionalNumber(entry.id),
-    documentId,
-    productName,
-    slug: toStringOrNull(entry.slug) ?? undefined,
-    price: toNullableNumber(entry.price),
-    unidadMedida: toStringOrNull(entry.unidadMedida) ?? undefined,
-  };
-}
-
-function mapLinea(node: unknown): FabricacionLine | undefined {
-  const entry = normalizeEntity<Record<string, unknown>>(node);
-  if (!entry) return undefined;
-  return {
-    id: toOptionalNumber(entry.id),
-    cantidad: toNumber(entry.cantidad),
-    unidad: toStringOrNull(entry.unidad) ?? "",
-    mermaPct: toNumber(entry.mermaPct),
-    nota: toStringOrNull(entry.nota),
-  };
-}
-
-function mapFabricacion(node: unknown): Fabricacion | undefined {
-  const entry = normalizeEntity<Record<string, unknown>>(node);
-  if (!entry) return undefined;
-
-  const documentId =
-    toStringOrNull(entry.documentId) ??
-    toStringOrNull(entry.document_id) ??
-    (entry.id != null ? String(entry.id) : null);
-  const nombre = toStringOrNull(entry.nombre) ?? "";
-  if (!documentId || !nombre) return undefined;
-
-  const lineasRaw = normalizeArray(entry.lineas);
-
-  const lineas = lineasRaw.map(mapLinea).filter((linea): linea is FabricacionLine => Boolean(linea));
-
-  return {
-    id: toOptionalNumber(entry.id),
-    documentId,
-    nombre,
-    batchSize: toNumber(entry.batchSize),
-    mermaPct: toNumber(entry.mermaPct),
-    costoManoObra: toNumber(entry.costoManoObra),
-    costoEmpaque: toNumber(entry.costoEmpaque),
-    overheadPct: toNumber(entry.overheadPct),
-    margenObjetivoPct: toNumber(entry.margenObjetivoPct),
-    ingredientesCostoTotal: toNumber(entry.ingredientesCostoTotal),
-    costoTotalBatch: toNumber(entry.costoTotalBatch),
-    costoUnitario: toNullableNumber(entry.costoUnitario),
-    precioSugerido: toNumber(entry.precioSugerido),
-    margenRealPct: toNumber(entry.margenRealPct),
-    lastCalculatedAt: toStringOrNull(entry.lastCalculatedAt),
-    createdAt: toStringOrNull(entry.createdAt) ?? undefined,
-    updatedAt: toStringOrNull(entry.updatedAt) ?? undefined,
-    publishedAt: toStringOrNull(entry.publishedAt) ?? undefined,
-    product: mapProduct(entry.product),
-    lineas,
-  };
-}
-
-const DEFAULT_POPULATE = "product,lineas";
+import { Fabricacion, FabricacionListResponse } from "@/types/fabricacion";
+import { ensureFabricacionPopulate, mapFabricacion, normalizeFabricacionPopulate } from "./shared";
 
 export async function GET(request: NextRequest) {
   try {
     const url = new URL(request.url);
     const params = new URLSearchParams(url.searchParams);
-    if (!params.has("populate")) {
-      params.set("populate", DEFAULT_POPULATE);
-    }
+    normalizeFabricacionPopulate(params);
+    ensureFabricacionPopulate(params);
     if (!params.has("pagination[page]")) {
       params.set("pagination[page]", params.get("page") ?? "1");
     }
@@ -141,6 +23,15 @@ export async function GET(request: NextRequest) {
     const text = await res.text();
     if (!res.ok) {
       console.error("[admin/fabricacion][GET] Strapi error", { status: res.status, body: text });
+      if (res.status === 400) {
+        return NextResponse.json(
+          {
+            error:
+              "Strapi rechazó la consulta de fabricación (parámetros inválidos). Intenta recargar o avisa al equipo si persiste.",
+          },
+          { status: 502 }
+        );
+      }
       return NextResponse.json({ error: "No se pudo obtener la información de fabricación" }, { status: 502 });
     }
 

--- a/app/api/admin/fabricacion/shared.ts
+++ b/app/api/admin/fabricacion/shared.ts
@@ -1,0 +1,156 @@
+import { Fabricacion, FabricacionLine, FabricacionProduct } from "@/types/fabricacion";
+
+function toNumber(value: unknown, fallback = 0): number {
+  const source = typeof value === "string" ? value.trim() : value;
+  const num = Number(source);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function toNullableNumber(value: unknown): number | null {
+  const source = typeof value === "string" ? value.trim() : value;
+  if (source === "" || source === null || source === undefined) return null;
+  const num = Number(source);
+  return Number.isFinite(num) ? num : null;
+}
+
+function toOptionalNumber(value: unknown): number | undefined {
+  const num = toNullableNumber(value);
+  return num === null ? undefined : num;
+}
+
+function toStringOrNull(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+  return value == null ? null : String(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function normalizeEntity<T extends Record<string, unknown>>(node: unknown): T | null {
+  if (!isRecord(node)) return null;
+  const record = node as Record<string, unknown>;
+  if (isRecord(record.data)) {
+    return normalizeEntity(record.data);
+  }
+  if (isRecord(record.attributes)) {
+    return { ...record, ...(record.attributes as Record<string, unknown>) } as T;
+  }
+  return record as T;
+}
+
+function normalizeArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (isRecord(value) && Array.isArray(value.data)) return value.data as unknown[];
+  return [];
+}
+
+function mapProduct(node: unknown): FabricacionProduct | null {
+  const entry = normalizeEntity<Record<string, unknown>>(node);
+  if (!entry) return null;
+  const documentId = toStringOrNull(entry.documentId) ?? toStringOrNull(entry.document_id);
+  const productName =
+    toStringOrNull(entry.productName) ?? toStringOrNull(entry.name) ?? toStringOrNull(entry.titulo) ?? "";
+  if (!documentId || !productName) return null;
+  return {
+    id: toOptionalNumber(entry.id),
+    documentId,
+    productName,
+    slug: toStringOrNull(entry.slug) ?? undefined,
+    price: toNullableNumber(entry.price),
+    unidadMedida: toStringOrNull(entry.unidadMedida) ?? undefined,
+  };
+}
+
+function mapLinea(node: unknown): FabricacionLine | undefined {
+  const entry = normalizeEntity<Record<string, unknown>>(node);
+  if (!entry) return undefined;
+  return {
+    id: toOptionalNumber(entry.id),
+    cantidad: toNumber(entry.cantidad),
+    unidad: toStringOrNull(entry.unidad) ?? "",
+    mermaPct: toNumber(entry.mermaPct),
+    nota: toStringOrNull(entry.nota),
+  };
+}
+
+export function mapFabricacion(node: unknown): Fabricacion | undefined {
+  const entry = normalizeEntity<Record<string, unknown>>(node);
+  if (!entry) return undefined;
+
+  const documentId =
+    toStringOrNull(entry.documentId) ??
+    toStringOrNull(entry.document_id) ??
+    (entry.id != null ? String(entry.id) : null);
+  const nombre = toStringOrNull(entry.nombre) ?? "";
+  if (!documentId || !nombre) return undefined;
+
+  const lineasRaw = normalizeArray(entry.lineas);
+
+  const lineas = lineasRaw.map(mapLinea).filter((linea): linea is FabricacionLine => Boolean(linea));
+
+  return {
+    id: toOptionalNumber(entry.id),
+    documentId,
+    nombre,
+    batchSize: toNumber(entry.batchSize),
+    mermaPct: toNumber(entry.mermaPct),
+    costoManoObra: toNumber(entry.costoManoObra),
+    costoEmpaque: toNumber(entry.costoEmpaque),
+    overheadPct: toNumber(entry.overheadPct),
+    margenObjetivoPct: toNumber(entry.margenObjetivoPct),
+    ingredientesCostoTotal: toNumber(entry.ingredientesCostoTotal),
+    costoTotalBatch: toNumber(entry.costoTotalBatch),
+    costoUnitario: toNullableNumber(entry.costoUnitario),
+    precioSugerido: toNumber(entry.precioSugerido),
+    margenRealPct: toNumber(entry.margenRealPct),
+    lastCalculatedAt: toStringOrNull(entry.lastCalculatedAt),
+    createdAt: toStringOrNull(entry.createdAt) ?? undefined,
+    updatedAt: toStringOrNull(entry.updatedAt) ?? undefined,
+    publishedAt: toStringOrNull(entry.publishedAt) ?? undefined,
+    product: mapProduct(entry.product),
+    lineas,
+  };
+}
+
+function hasPopulate(params: URLSearchParams): boolean {
+  for (const key of params.keys()) {
+    if (key === "populate" || key.startsWith("populate[")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function normalizeFabricacionPopulate(params: URLSearchParams): void {
+  const simplePopulate = params.getAll("populate");
+  if (simplePopulate.length === 0) return;
+
+  params.delete("populate");
+
+  const entries = simplePopulate
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  for (const key of entries) {
+    if (key === "product") {
+      params.set("populate[product]", "*");
+      continue;
+    }
+    if (key === "lineas") {
+      params.set("populate[lineas][populate]", "ingredient");
+      continue;
+    }
+    params.set(`populate[${key}]`, "*");
+  }
+}
+
+export function ensureFabricacionPopulate(params: URLSearchParams): void {
+  if (hasPopulate(params)) return;
+  params.set("populate[product]", "*");
+  params.set("populate[lineas][populate]", "ingredient");
+}

--- a/lib/admin/fabricacion-api.ts
+++ b/lib/admin/fabricacion-api.ts
@@ -1,11 +1,37 @@
-import { FabricacionListResponse } from "@/types/fabricacion";
+import { Fabricacion, FabricacionListResponse } from "@/types/fabricacion";
+
+function extractErrorMessage(payload: string | null): string {
+  if (!payload) return "No se pudieron obtener las órdenes de fabricación";
+  try {
+    const parsed = JSON.parse(payload);
+    if (typeof parsed?.error === "string") return parsed.error;
+    if (parsed?.error && typeof parsed.error.message === "string") return parsed.error.message;
+  } catch {
+    // ignore, fall back to raw payload
+  }
+  return payload;
+}
 
 export async function listFabricaciones(): Promise<FabricacionListResponse> {
   const res = await fetch(`/api/admin/fabricacion`, { cache: "no-store" });
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(text || "No se pudieron obtener las órdenes de fabricación");
+    throw new Error(extractErrorMessage(text));
   }
   const json = (await res.json()) as FabricacionListResponse;
+  return json;
+}
+
+export async function getFabricacion(documentId: string): Promise<Fabricacion> {
+  const trimmed = documentId?.trim();
+  if (!trimmed) {
+    throw new Error("Falta el identificador de la orden de fabricación");
+  }
+  const res = await fetch(`/api/admin/fabricacion/${encodeURIComponent(trimmed)}`, { cache: "no-store" });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(extractErrorMessage(text));
+  }
+  const json = (await res.json()) as Fabricacion;
   return json;
 }


### PR DESCRIPTION
## Summary
- normalize the fabricación list API populate parameters and surface a clearer message when Strapi rejects the query
- extract shared mappers/helpers and add a detail endpoint that fetches fabricación records by documentId with the correct populate syntax
- expose a fabricacion client fetcher that parses API error payloads for better UI messages

## Testing
- npm run lint *(fails due to pre-existing lint issues unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d695e0d4148321938fd25cb1a29872